### PR TITLE
feat(phase-2): Ecommerce Core

### DIFF
--- a/packages/backend/src/access/is-owner-or-admin.ts
+++ b/packages/backend/src/access/is-owner-or-admin.ts
@@ -1,0 +1,18 @@
+import type { Access } from 'payload'
+
+/**
+ * Allows access if admin, or if the document's `user` field equals the current user.
+ * Use for collections that have a user relationship (e.g. addresses).
+ */
+export const isOwnerOrAdmin =
+  (userField = 'user'): Access =>
+  ({ req }) => {
+    const user = req.user
+    if (!user) return false
+    if (user.role === 'admin') return true
+    return {
+      [userField]: {
+        equals: user.id,
+      },
+    }
+  }

--- a/packages/backend/src/collections/users/index.ts
+++ b/packages/backend/src/collections/users/index.ts
@@ -128,7 +128,12 @@ export const Users: CollectionConfig = {
     },
 
     // tenant field added in Phase 4 (multivendor plugin — tenants collection)
-    // addresses field added in Phase 2 (ecommerce plugin — addresses collection)
+    {
+      name: 'addresses',
+      type: 'relationship',
+      relationTo: 'addresses',
+      hasMany: true,
+    },
   ],
 
   hooks: {

--- a/packages/backend/src/lib/currencies.ts
+++ b/packages/backend/src/lib/currencies.ts
@@ -1,0 +1,21 @@
+/**
+ * Currency options from SUPPORTED_CURRENCIES env.
+ * Used by Products, Shipping Methods, and other collections.
+ */
+const SUPPORTED = (process.env.SUPPORTED_CURRENCIES || 'USD,BDT').split(',').map((c) => c.trim())
+
+const LABELS: Record<string, string> = {
+  USD: 'US Dollar (USD)',
+  BDT: 'Bangladeshi Taka (BDT)',
+}
+
+export function getCurrencyOptions(): { label: string; value: string }[] {
+  return SUPPORTED.map((code) => ({
+    label: LABELS[code] ?? code,
+    value: code,
+  }))
+}
+
+export function getDefaultCurrency(): string {
+  return process.env.DEFAULT_CURRENCY || 'USD'
+}

--- a/packages/backend/src/lib/redis.ts
+++ b/packages/backend/src/lib/redis.ts
@@ -17,4 +17,5 @@ export const cachedCollections = {
   categories: true,
   pages: true,
   media: true,
+  products: true,
 } as const

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -14,6 +14,10 @@ import { Media } from './collections/media'
 import { Pages } from './collections/pages'
 import { Categories } from './collections/categories'
 
+import { ecommercePlugin } from './plugins/ecommerce'
+import { inventoryPlugin } from './plugins/inventory'
+import { shippingPlugin } from './plugins/shipping'
+
 import { Header } from './globals/header'
 import { Footer } from './globals/footer'
 import { PlatformSettings } from './globals/platform-settings'
@@ -86,6 +90,23 @@ export default buildConfig({
     redisCache({
       redis: redisConfig,
       collections: cachedCollections,
+    }),
+
+    // Phase 2: Ecommerce Core
+    ecommercePlugin({
+      enabled: true,
+      currencies: (process.env.SUPPORTED_CURRENCIES || 'USD,BDT').split(','),
+      defaultCurrency: process.env.DEFAULT_CURRENCY || 'USD',
+      allowGuestCheckout: process.env.GUEST_CHECKOUT_ENABLED === 'true',
+    }),
+    inventoryPlugin({
+      enabled: process.env.INVENTORY_ENABLED !== 'false',
+      trackMovements: true,
+      lowStockThreshold: Number(process.env.LOW_STOCK_THRESHOLD || '10'),
+    }),
+    shippingPlugin({
+      enabled: true,
+      model: (process.env.SHIPPING_MODEL || 'platform') as 'platform' | 'vendor' | 'hybrid',
     }),
 
     // Future plugins (added per phase):

--- a/packages/backend/src/plugins/ecommerce/collections/addresses.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/addresses.ts
@@ -1,0 +1,47 @@
+import type { CollectionConfig } from 'payload'
+import { isOwnerOrAdmin } from '../../../access/is-owner-or-admin'
+
+export const Addresses: CollectionConfig = {
+  slug: 'addresses',
+  admin: {
+    useAsTitle: 'label',
+    defaultColumns: ['label', 'firstName', 'lastName', 'city', 'country', 'user'],
+    group: 'Ecommerce',
+  },
+  access: {
+    create: ({ req }) => Boolean(req.user),
+    read: isOwnerOrAdmin(),
+    update: isOwnerOrAdmin(),
+    delete: isOwnerOrAdmin(),
+  },
+  hooks: {
+    beforeChange: [
+      ({ data, req }) => {
+        if (req.user?.role !== 'admin' && data) {
+          data.user = req.user!.id
+        }
+        return data
+      },
+    ],
+  },
+  fields: [
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+    },
+    { name: 'label', type: 'text', required: true },
+    { name: 'firstName', type: 'text', required: true },
+    { name: 'lastName', type: 'text', required: true },
+    { name: 'street1', type: 'text', required: true },
+    { name: 'street2', type: 'text' },
+    { name: 'city', type: 'text', required: true },
+    { name: 'state', type: 'text' },
+    { name: 'postalCode', type: 'text' },
+    { name: 'country', type: 'text', required: true },
+    { name: 'phone', type: 'text' },
+    { name: 'isDefault', type: 'checkbox', defaultValue: false },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/ecommerce/collections/carts.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/carts.ts
@@ -1,0 +1,106 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const Carts: CollectionConfig = {
+  slug: 'carts',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['user', 'guestId', 'subtotal', 'expiresAt'],
+    group: 'Ecommerce',
+  },
+  hooks: {
+    beforeChange: [
+      async ({ data, req }) => {
+        if (!data?.items || !Array.isArray(data.items)) return data
+
+        for (const item of data.items) {
+          const variantId = typeof item.variant === 'object' ? item.variant?.id : item.variant
+          const productId = typeof item.product === 'object' ? item.product?.id : item.product
+          if (variantId && productId) {
+            const variant = await req.payload.findByID({
+              collection: 'product-variants',
+              id: variantId,
+            })
+            const vProductId = typeof variant?.product === 'object' ? variant?.product?.id : variant?.product
+            if (variant && vProductId !== productId) {
+              throw new Error(`Variant ${variantId} does not belong to product ${productId}`)
+            }
+          }
+        }
+
+        const subtotal = data.items.reduce(
+          (sum: number, i: { quantity?: number; unitPrice?: number }) =>
+            sum + (Number(i.quantity) || 0) * (Number(i.unitPrice) || 0),
+          0
+        )
+        data.subtotal = Math.round(subtotal * 100) / 100
+        return data
+      },
+    ],
+  },
+  access: {
+    create: ({ req }) => Boolean(req.user),
+    read: ({ req }) => {
+      if (req.user?.role === 'admin') return true
+      if (req.user) return { user: { equals: req.user.id } }
+      return false
+    },
+    update: ({ req }) => {
+      if (req.user?.role === 'admin') return true
+      if (req.user) return { user: { equals: req.user.id } }
+      return false
+    },
+    delete: ({ req }) => {
+      if (req.user?.role === 'admin') return true
+      if (req.user) return { user: { equals: req.user.id } }
+      return false
+    },
+  },
+  fields: [
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: { description: 'Null for guest carts.' },
+    },
+    {
+      name: 'guestId',
+      type: 'text',
+      index: true,
+      admin: { description: 'UUID for guest identification.' },
+    },
+    {
+      name: 'items',
+      type: 'array',
+      required: true,
+      defaultValue: [],
+      fields: [
+        {
+          name: 'product',
+          type: 'relationship',
+          relationTo: 'products',
+          required: true,
+        },
+        {
+          name: 'variant',
+          type: 'relationship',
+          relationTo: 'product-variants',
+        },
+        { name: 'quantity', type: 'number', required: true, min: 1 },
+        { name: 'unitPrice', type: 'number', required: true, min: 0 },
+      ],
+    },
+    {
+      name: 'subtotal',
+      type: 'number',
+      defaultValue: 0,
+      admin: { readOnly: true, description: 'Auto-calculated from items.' },
+    },
+    {
+      name: 'expiresAt',
+      type: 'date',
+      admin: { description: 'Guest carts expire.' },
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/ecommerce/collections/product-variants.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/product-variants.ts
@@ -1,0 +1,49 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const ProductVariants: CollectionConfig = {
+  slug: 'product-variants',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'sku', 'price', 'product', 'isActive'],
+    group: 'Ecommerce',
+  },
+  access: {
+    create: isAdmin,
+    read: ({ req }) => {
+      if (!req.user) return { isActive: { equals: true } }
+      if (req.user.role === 'admin') return true
+      return { isActive: { equals: true } }
+    },
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'product',
+      type: 'relationship',
+      relationTo: 'products',
+      required: true,
+    },
+    { name: 'name', type: 'text', required: true },
+    { name: 'sku', type: 'text', unique: true, admin: { description: 'Unique per variant. Leave empty for auto-generated.' } },
+    { name: 'price', type: 'number', required: true, min: 0 },
+    { name: 'compareAtPrice', type: 'number', min: 0 },
+    {
+      name: 'options',
+      type: 'array',
+      fields: [
+        { name: 'name', type: 'text', required: true },
+        { name: 'value', type: 'text', required: true },
+      ],
+    },
+    {
+      name: 'image',
+      type: 'upload',
+      relationTo: 'media',
+    },
+    { name: 'weight', type: 'number', min: 0 },
+    { name: 'isActive', type: 'checkbox', defaultValue: true },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/ecommerce/collections/products.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/products.ts
@@ -1,0 +1,108 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { slugField } from '../../../fields/slug'
+import { getCurrencyOptions } from '../../../lib/currencies'
+
+export const Products: CollectionConfig = {
+  slug: 'products',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'slug', 'status', 'basePrice', 'currency', 'publishedAt'],
+    group: 'Ecommerce',
+  },
+  access: {
+    create: isAdmin,
+    read: ({ req }) => {
+      if (!req.user) return { status: { equals: 'published' } }
+      if (req.user.role === 'admin') return true
+      return { status: { equals: 'published' } }
+    },
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    { name: 'name', type: 'text', required: true, localized: true },
+    slugField('name'),
+    {
+      name: 'description',
+      type: 'richText',
+      localized: true,
+    },
+    {
+      name: 'shortDescription',
+      type: 'textarea',
+      localized: true,
+    },
+    { name: 'sku', type: 'text' },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'draft',
+      options: [
+        { label: 'Draft', value: 'draft' },
+        { label: 'Pending Review', value: 'pending-review' },
+        { label: 'Published', value: 'published' },
+        { label: 'Archived', value: 'archived' },
+      ],
+    },
+    { name: 'featured', type: 'checkbox', defaultValue: false },
+    {
+      name: 'categories',
+      type: 'relationship',
+      relationTo: 'categories',
+      hasMany: true,
+    },
+    {
+      name: 'tags',
+      type: 'array',
+      fields: [{ name: 'tag', type: 'text' }],
+    },
+    {
+      name: 'images',
+      type: 'array',
+      fields: [
+        {
+          name: 'image',
+          type: 'upload',
+          relationTo: 'media',
+          required: true,
+        },
+      ],
+    },
+    { name: 'basePrice', type: 'number', required: true, min: 0 },
+    { name: 'compareAtPrice', type: 'number', min: 0 },
+    { name: 'costPrice', type: 'number', min: 0 },
+    {
+      name: 'currency',
+      type: 'select',
+      required: true,
+      defaultValue: 'USD',
+      options: getCurrencyOptions(),
+    },
+    { name: 'taxable', type: 'checkbox', defaultValue: true },
+    { name: 'weight', type: 'number', min: 0 },
+    {
+      name: 'dimensions',
+      type: 'group',
+      fields: [
+        { name: 'length', type: 'number', min: 0 },
+        { name: 'width', type: 'number', min: 0 },
+        { name: 'height', type: 'number', min: 0 },
+      ],
+    },
+    { name: 'hasVariants', type: 'checkbox', defaultValue: false },
+    {
+      name: 'meta',
+      type: 'group',
+      label: 'SEO',
+      fields: [
+        { name: 'title', type: 'text', localized: true },
+        { name: 'description', type: 'textarea', localized: true },
+        { name: 'image', type: 'upload', relationTo: 'media' },
+      ],
+    },
+    { name: 'publishedAt', type: 'date' },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/ecommerce/index.ts
+++ b/packages/backend/src/plugins/ecommerce/index.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from 'payload'
+import { Products } from './collections/products'
+import { ProductVariants } from './collections/product-variants'
+import { Carts } from './collections/carts'
+import { Addresses } from './collections/addresses'
+
+export interface EcommercePluginOptions {
+  enabled?: boolean
+  currencies?: string[]
+  defaultCurrency?: string
+  allowGuestCheckout?: boolean
+}
+
+export const ecommercePlugin =
+  (options: EcommercePluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [
+        ...(incomingConfig.collections || []),
+        Products,
+        ProductVariants,
+        Carts,
+        Addresses,
+      ],
+    }
+  }

--- a/packages/backend/src/plugins/inventory/collections/stock-levels.ts
+++ b/packages/backend/src/plugins/inventory/collections/stock-levels.ts
@@ -1,0 +1,40 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const StockLevels: CollectionConfig = {
+  slug: 'stock-levels',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['product', 'variant', 'location', 'quantity', 'reservedQuantity'],
+    group: 'Inventory',
+  },
+  access: {
+    create: isAdmin,
+    read: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'product',
+      type: 'relationship',
+      relationTo: 'products',
+      required: true,
+    },
+    {
+      name: 'variant',
+      type: 'relationship',
+      relationTo: 'product-variants',
+      admin: { description: 'Optional. Leave empty for product-level stock (no variants).' },
+    },
+    {
+      name: 'location',
+      type: 'relationship',
+      relationTo: 'stock-locations',
+      required: true,
+    },
+    { name: 'quantity', type: 'number', required: true, min: 0 },
+    { name: 'reservedQuantity', type: 'number', defaultValue: 0, min: 0 },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/inventory/collections/stock-locations.ts
+++ b/packages/backend/src/plugins/inventory/collections/stock-locations.ts
@@ -1,0 +1,34 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const StockLocations: CollectionConfig = {
+  slug: 'stock-locations',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'code', 'isActive'],
+    group: 'Inventory',
+  },
+  access: {
+    create: isAdmin,
+    read: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    { name: 'code', type: 'text', required: true, unique: true },
+    {
+      name: 'address',
+      type: 'group',
+      fields: [
+        { name: 'street', type: 'text' },
+        { name: 'city', type: 'text' },
+        { name: 'state', type: 'text' },
+        { name: 'country', type: 'text' },
+        { name: 'postalCode', type: 'text' },
+      ],
+    },
+    { name: 'isActive', type: 'checkbox', defaultValue: true },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/inventory/index.ts
+++ b/packages/backend/src/plugins/inventory/index.ts
@@ -1,0 +1,25 @@
+import type { Plugin } from 'payload'
+import { StockLocations } from './collections/stock-locations'
+import { StockLevels } from './collections/stock-levels'
+
+export interface InventoryPluginOptions {
+  enabled?: boolean
+  trackMovements?: boolean
+  lowStockThreshold?: number
+}
+
+export const inventoryPlugin =
+  (options: InventoryPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [
+        ...(incomingConfig.collections || []),
+        StockLocations,
+        StockLevels,
+      ],
+    }
+  }

--- a/packages/backend/src/plugins/shipping/collections/shipping-methods.ts
+++ b/packages/backend/src/plugins/shipping/collections/shipping-methods.ts
@@ -1,0 +1,49 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { getCurrencyOptions } from '../../../lib/currencies'
+
+export const ShippingMethods: CollectionConfig = {
+  slug: 'shipping-methods',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'zone', 'type', 'rate', 'currency'],
+    group: 'Shipping',
+  },
+  access: {
+    create: isAdmin,
+    read: () => true,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    {
+      name: 'zone',
+      type: 'relationship',
+      relationTo: 'shipping-zones',
+      required: true,
+    },
+    {
+      name: 'type',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Flat Rate', value: 'flat' },
+        { label: 'Per Item', value: 'per-item' },
+        { label: 'Weight Based', value: 'weight-based' },
+      ],
+    },
+    { name: 'rate', type: 'number', required: true, min: 0 },
+    {
+      name: 'currency',
+      type: 'select',
+      required: true,
+      defaultValue: 'USD',
+      options: getCurrencyOptions(),
+    },
+    { name: 'minOrderValue', type: 'number', min: 0 },
+    { name: 'maxOrderValue', type: 'number', min: 0 },
+    { name: 'isActive', type: 'checkbox', defaultValue: true },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/shipping/collections/shipping-zones.ts
+++ b/packages/backend/src/plugins/shipping/collections/shipping-zones.ts
@@ -1,0 +1,28 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const ShippingZones: CollectionConfig = {
+  slug: 'shipping-zones',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'countries', 'isActive'],
+    group: 'Shipping',
+  },
+  access: {
+    create: isAdmin,
+    read: () => true,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    {
+      name: 'countries',
+      type: 'array',
+      fields: [{ name: 'code', type: 'text', required: true }],
+      admin: { description: 'ISO country codes (e.g. BD, US). Empty = rest of world.' },
+    },
+    { name: 'isActive', type: 'checkbox', defaultValue: true },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/shipping/index.ts
+++ b/packages/backend/src/plugins/shipping/index.ts
@@ -1,0 +1,24 @@
+import type { Plugin } from 'payload'
+import { ShippingZones } from './collections/shipping-zones'
+import { ShippingMethods } from './collections/shipping-methods'
+
+export interface ShippingPluginOptions {
+  enabled?: boolean
+  model?: 'platform' | 'vendor' | 'hybrid'
+}
+
+export const shippingPlugin =
+  (options: ShippingPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [
+        ...(incomingConfig.collections || []),
+        ShippingZones,
+        ShippingMethods,
+      ],
+    }
+  }


### PR DESCRIPTION
## Phase 2: Ecommerce Core

Implements Phase 2 scope per MULTIVENDOR-ARCHITECTURE.

### Ecommerce Plugin
- **Products** — name, slug, status, categories, pricing, variants flag, localization
- **Product Variants** — product, options, price, SKU (unique)
- **Carts** — user, items (product, variant, quantity, unitPrice), subtotal auto-calc
- **Addresses** — user, label, full address fields; user enforced server-side for non-admins

### Inventory Plugin
- **Stock Locations** — name, code, address
- **Stock Levels** — product, variant, location, quantity, reservedQuantity

### Shipping Plugin
- **Shipping Zones** — name, countries
- **Shipping Methods** — zone, type (flat/per-item/weight-based), rate, currency

### Enhancements
- Cart: subtotal computed from items; variant must belong to product when both set
- Address: `beforeChange` sets user for non-admins
- Currencies: `lib/currencies.ts` + env-based options for Products and Shipping Methods
- OpenAPI: `docs/openapi.yaml` for API testing (Postman/Swagger import)
