### PR TITLE
Phase 3.0: Payments & Orders Core + Auth Enhancement

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -9,6 +9,10 @@
 # Postgres (default)
 DATABASE_URI=postgres://postgres:postgres@localhost:5432/bs-commerce
 
+# Postgres ID type: uuid (default, string) | serial (integer). See docs/ID-STANDARD.md
+# uuid = DB-agnostic, no type confusion. serial = only if existing DB has integer IDs.
+DATABASE_ID_TYPE=uuid
+
 # MongoDB (alternative — swap adapter in payload.config.ts)
 # DATABASE_URI=mongodb://localhost:27017/bs-commerce
 
@@ -24,6 +28,14 @@ REDIS_URL=redis://localhost:6379
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_STOREFRONT_URL=http://localhost:3001
 PAYLOAD_SECRET=change-this-to-a-long-random-secret-key
+
+# ═══════════════════════════════════════════════════
+# AUTH — Email / Phone (see docs/AUTH-ENHANCEMENT.md)
+# Decision #18: email OR phone + password.
+# AUTH_REQUIRED_IDENTIFIER: email | phone | either (default)
+AUTH_REQUIRED_IDENTIFIER=either
+# Must match AUTH_REQUIRED_IDENTIFIER for custom create-first-user form
+NEXT_PUBLIC_AUTH_REQUIRED_IDENTIFIER=either
 
 # ═══════════════════════════════════════════════════
 # LOCALIZATION

--- a/packages/backend/src/access/is-order-owner-or-admin.ts
+++ b/packages/backend/src/access/is-order-owner-or-admin.ts
@@ -1,0 +1,21 @@
+import type { Access } from 'payload'
+
+/**
+ * Allows access if admin, or if the order belongs to the current user (customer field),
+ * or if guest and they provide order ID + guestEmail match.
+ * Used for Orders collection.
+ */
+export const isOrderOwnerOrAdmin: Access = ({ req, id }) => {
+  const user = req.user
+  if (!user && !id) return false
+  if (user?.role === 'admin') return true
+  if (user) {
+    return {
+      customer: {
+        equals: user.id,
+      },
+    }
+  }
+  // Guest: can only read by ID + email verification (handled at API level)
+  return false
+}

--- a/packages/backend/src/app/(payload)/admin/importMap.js
+++ b/packages/backend/src/app/(payload)/admin/importMap.js
@@ -21,6 +21,7 @@ import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93
 import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { default as default_94dc7064f1ac3d729baa1339d079c9c1 } from '../../../components/CreateFirstUser'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 export const importMap = {
@@ -47,5 +48,6 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "/components/CreateFirstUser#default": default_94dc7064f1ac3d729baa1339d079c9c1,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/packages/backend/src/collections/users/index.ts
+++ b/packages/backend/src/collections/users/index.ts
@@ -1,6 +1,11 @@
 import type { CollectionConfig, FieldAccess, PayloadRequest } from 'payload'
 import { isAdmin } from '../../access/is-admin'
 import { isSelfOrAdmin } from '../../access/is-self-or-admin'
+import {
+  getAuthRequiredIdentifier,
+  toLoginIdentifier,
+  validateAuthIdentifier,
+} from '../../lib/auth-config'
 
 // Field-level access: must return boolean only (FieldAccess, not collection Access)
 const adminOnly: FieldAccess = ({ req }) => req.user?.role === 'admin'
@@ -17,10 +22,12 @@ export const Users: CollectionConfig = {
     verify: false,
     maxLoginAttempts: 5,
     lockTime: 600 * 1000, // 10 minutes
+    // Decision #18: login with email OR phone. username stores the login identifier (email or phone).
+    loginWithUsername: { allowEmailLogin: true },
   },
   admin: {
-    useAsTitle: 'email',
-    defaultColumns: ['email', 'phone', 'role', 'status', 'createdAt'],
+    useAsTitle: 'username',
+    defaultColumns: ['username', 'email', 'phone', 'role', 'status', 'createdAt'],
     group: 'Platform',
   },
   access: {
@@ -37,7 +44,7 @@ export const Users: CollectionConfig = {
       type: 'email',
       unique: true,
       admin: {
-        description: 'Required if phone is not provided.',
+        description: 'Required if phone is not provided (configurable via AUTH_REQUIRED_IDENTIFIER).',
       },
     },
     {
@@ -45,8 +52,20 @@ export const Users: CollectionConfig = {
       type: 'text',
       unique: true,
       admin: {
-        description: 'Required if email is not provided.',
+        description: 'Required if email is not provided (configurable via AUTH_REQUIRED_IDENTIFIER).',
       },
+    },
+    {
+      name: 'username',
+      type: 'text',
+      unique: true,
+      admin: {
+        description: 'Login identifier — auto-set from email or phone. Do not edit.',
+        readOnly: true,
+        condition: (_, __, { operation }) => operation !== 'create', // Hide on create (auto-populated); show on edit
+      },
+      validate: (val: unknown) =>
+        val && typeof val === 'string' && val.trim().length > 0 ? true : 'Required',
     },
 
     // ─── Profile ──────────────────────────────────────────────────────────────
@@ -138,10 +157,38 @@ export const Users: CollectionConfig = {
 
   hooks: {
     beforeValidate: [
-      ({ data }) => {
-        if (!data?.email && !data?.phone) {
-          throw new Error('At least one of email or phone is required.')
+      ({ data, originalDoc }) => {
+        if (!data) return data
+
+        const identifier = getAuthRequiredIdentifier()
+        validateAuthIdentifier(identifier, data)
+
+        // create-first-user may send email in username; sync for storage
+        const rawEmail = data.email ?? originalDoc?.email
+        const rawPhone = data.phone ?? originalDoc?.phone
+        const rawUsername = data.username
+        if (!rawEmail && rawUsername && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(rawUsername).trim())) {
+          data.email = String(rawUsername).trim().toLowerCase()
         }
+        if (!rawPhone && rawUsername && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(rawUsername).trim()) && String(rawUsername).trim()) {
+          data.phone = String(rawUsername).trim()
+        }
+
+        const email = data.email ?? originalDoc?.email
+        const phone = data.phone ?? originalDoc?.phone
+        const loginId = toLoginIdentifier(email, phone, data.username)
+        if (loginId) {
+          data.username = loginId.toLowerCase()
+        }
+
+        // Reset verification when identifier changes
+        if (originalDoc && data.email !== undefined && String(data.email || '').trim() !== String(originalDoc.email || '').trim()) {
+          data.emailVerified = false
+        }
+        if (originalDoc && data.phone !== undefined && String(data.phone || '').trim() !== String(originalDoc.phone || '').trim()) {
+          data.phoneVerified = false
+        }
+
         return data
       },
     ],

--- a/packages/backend/src/components/CreateFirstUser/index.tsx
+++ b/packages/backend/src/components/CreateFirstUser/index.tsx
@@ -1,0 +1,195 @@
+/**
+ * Custom create-first-user view: Email + Password only when AUTH_REQUIRED_IDENTIFIER=email,
+ * avoiding the Username field required by Payload's loginWithUsername.
+ */
+'use client'
+
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@payloadcms/ui'
+import type { AdminViewClientProps } from 'payload'
+
+type IdentifierMode = 'email' | 'phone' | 'either'
+
+function CreateFirstUser(_props: AdminViewClientProps) {
+  const identifier: IdentifierMode =
+    (typeof process !== 'undefined' &&
+      (process.env as { NEXT_PUBLIC_AUTH_REQUIRED_IDENTIFIER?: string }).NEXT_PUBLIC_AUTH_REQUIRED_IDENTIFIER as IdentifierMode) ||
+    'either'
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const showEmailOnly = identifier === 'email'
+  const showPhoneOnly = identifier === 'phone'
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+
+    const form = e.currentTarget
+    const formData = new FormData(form)
+    const email = formData.get('email')?.toString().trim()
+    const phone = formData.get('phone')?.toString().trim()
+    const password = formData.get('password')?.toString()
+    const confirmPassword = formData.get('confirmPassword')?.toString()
+
+    if (!password || password.length < 8) {
+      setError('Password must be at least 8 characters.')
+      setSubmitting(false)
+      return
+    }
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.')
+      setSubmitting(false)
+      return
+    }
+    if (showEmailOnly && !email) {
+      setError('Email is required.')
+      setSubmitting(false)
+      return
+    }
+    if (showPhoneOnly && !phone) {
+      setError('Phone is required.')
+      setSubmitting(false)
+      return
+    }
+    if (!showEmailOnly && !showPhoneOnly && !email && !phone) {
+      setError('Email or phone is required.')
+      setSubmitting(false)
+      return
+    }
+
+    try {
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: showEmailOnly ? email : email || undefined,
+          phone: showPhoneOnly ? phone : phone || undefined,
+          password,
+          role: 'admin',
+          status: 'active',
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setError(data.errors?.[0]?.message ?? data.message ?? 'Failed to create user.')
+        setSubmitting(false)
+        return
+      }
+      router.push('/admin')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create user.')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: 400, margin: '0 auto' }}>
+      <style>{`
+        .create-first-user-form button[type="submit"] { width: 100%; }
+      `}</style>
+      <h1 style={{ marginBottom: '0.5rem' }}>Welcome</h1>
+      <p style={{ color: 'var(--theme-elevation-500)', marginBottom: '1.5rem' }}>
+        To begin, create your first user. This will be an admin account.
+      </p>
+      <form className="create-first-user-form" onSubmit={handleSubmit}>
+        {!showPhoneOnly && (
+          <div style={{ marginBottom: '1rem' }}>
+            <label htmlFor="email" style={{ display: 'block', marginBottom: '0.25rem' }}>
+              Email{showEmailOnly ? ' *' : ''}
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required={showEmailOnly}
+              placeholder="admin@example.com"
+              style={{
+                width: '100%',
+                padding: '0.5rem 0.75rem',
+                borderRadius: 4,
+                border: '1px solid var(--theme-elevation-400)',
+                background: 'var(--theme-elevation-100)',
+              }}
+            />
+          </div>
+        )}
+        {!showEmailOnly && (
+          <div style={{ marginBottom: '1rem' }}>
+            <label htmlFor="phone" style={{ display: 'block', marginBottom: '0.25rem' }}>
+              Phone{showPhoneOnly ? ' *' : ''}
+            </label>
+            <input
+              id="phone"
+              name="phone"
+              type="tel"
+              autoComplete="tel"
+              required={showPhoneOnly}
+              placeholder="+8801712345678"
+              style={{
+                width: '100%',
+                padding: '0.5rem 0.75rem',
+                borderRadius: 4,
+                border: '1px solid var(--theme-elevation-400)',
+                background: 'var(--theme-elevation-100)',
+              }}
+            />
+          </div>
+        )}
+        <div style={{ marginBottom: '1rem' }}>
+          <label htmlFor="password" style={{ display: 'block', marginBottom: '0.25rem' }}>
+            New Password *
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            required
+            style={{
+              width: '100%',
+              padding: '0.5rem 0.75rem',
+              borderRadius: 4,
+              border: '1px solid var(--theme-elevation-400)',
+              background: 'var(--theme-elevation-100)',
+            }}
+          />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <label htmlFor="confirmPassword" style={{ display: 'block', marginBottom: '0.25rem' }}>
+            Confirm Password *
+          </label>
+          <input
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+            style={{
+              width: '100%',
+              padding: '0.5rem 0.75rem',
+              borderRadius: 4,
+              border: '1px solid var(--theme-elevation-400)',
+              background: 'var(--theme-elevation-100)',
+            }}
+          />
+        </div>
+        {error && (
+          <p style={{ color: 'var(--theme-error-500)', marginBottom: '1rem', fontSize: 14 }}>{error}</p>
+        )}
+        <div style={{ marginTop: '0.5rem' }}>
+          <Button buttonStyle="primary" type="submit" disabled={submitting}>
+            {submitting ? 'Creating...' : 'Create'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default CreateFirstUser

--- a/packages/backend/src/endpoints/auth-login.ts
+++ b/packages/backend/src/endpoints/auth-login.ts
@@ -1,0 +1,47 @@
+/**
+ * Custom login endpoint: accepts `identifier` (email or phone) + password.
+ * Forwards to Payload's login with email or username based on format.
+ * Decision #18: email OR phone login.
+ */
+import type { Endpoint } from 'payload'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export const authLoginEndpoint: Endpoint = {
+  path: '/auth/login',
+  method: 'post',
+  handler: async (req) => {
+    const data = (await (req as Request).json?.().catch(() => ({}))) || {}
+    const { identifier, password } = data
+
+    if (!identifier || typeof identifier !== 'string' || !identifier.trim()) {
+      return Response.json({ errors: [{ message: 'Identifier (email or phone) is required.' }] }, { status: 400 })
+    }
+    if (!password || typeof password !== 'string') {
+      return Response.json({ errors: [{ message: 'Password is required.' }] }, { status: 400 })
+    }
+
+    const trimmed = identifier.trim().toLowerCase()
+    const isEmail = EMAIL_REGEX.test(trimmed)
+
+    const payload = req.payload
+    const loginData = isEmail
+      ? { email: trimmed, password }
+      : { username: identifier.trim(), password }
+
+    try {
+      const result = await payload.login({
+        collection: 'users',
+        // loginWithUsername accepts email or username; Payload's generated types expect email
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: loginData as any,
+        req,
+      })
+      return Response.json(result, { status: 200 })
+    } catch (err) {
+      const status = (err as { status?: number })?.status ?? 401
+      const message = err instanceof Error ? err.message : 'Authentication failed'
+      return Response.json({ errors: [{ message }] }, { status })
+    }
+  },
+}

--- a/packages/backend/src/lib/auth-config.ts
+++ b/packages/backend/src/lib/auth-config.ts
@@ -1,0 +1,59 @@
+/**
+ * Auth configuration from env.
+ * Decision #18: email OR phone + password. Configurable.
+ *
+ * AUTH_REQUIRED_IDENTIFIER:
+ * - email  = email required, phone optional
+ * - phone  = phone required, email optional
+ * - either = at least one of email or phone required (default)
+ */
+export type AuthRequiredIdentifier = 'email' | 'phone' | 'either'
+
+export function getAuthRequiredIdentifier(): AuthRequiredIdentifier {
+  const v = process.env.AUTH_REQUIRED_IDENTIFIER?.toLowerCase()
+  if (v === 'email' || v === 'phone' || v === 'either') return v
+  return 'either'
+}
+
+/** Basic email pattern; phone often starts with + or digits. */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function validateAuthIdentifier(
+  identifier: AuthRequiredIdentifier,
+  data: { email?: string | null; phone?: string | null; username?: string | null }
+): void {
+  // create-first-user form may submit identifier in username; use it as fallback
+  let email = (data.email ?? '').toString().trim()
+  let phone = (data.phone ?? '').toString().trim()
+  const username = (data.username ?? '').toString().trim()
+  if (!email && username && EMAIL_REGEX.test(username)) email = username
+  if (!phone && username && !EMAIL_REGEX.test(username) && username.length > 0) phone = username
+
+  if (identifier === 'email' && !email) {
+    throw new Error('Email is required.')
+  }
+  if (identifier === 'phone' && !phone) {
+    throw new Error('Phone is required.')
+  }
+  if (identifier === 'either' && !email && !phone) {
+    throw new Error('At least one of email or phone is required.')
+  }
+}
+
+/**
+ * Returns the value to store in username for login lookup.
+ * Payload: email login uses email field; phone login uses username field.
+ * So when both exist, prefer phone for username so BOTH logins work.
+ */
+export function toLoginIdentifier(
+  email?: string | null,
+  phone?: string | null,
+  username?: string | null
+): string {
+  let e = (email ?? '').toString().trim().toLowerCase()
+  let p = (phone ?? '').toString().trim()
+  const u = (username ?? '').toString().trim()
+  if (!e && u && EMAIL_REGEX.test(u)) e = u.toLowerCase()
+  if (!p && u && !EMAIL_REGEX.test(u)) p = u
+  return p || e
+}

--- a/packages/backend/src/lib/process-checkout.ts
+++ b/packages/backend/src/lib/process-checkout.ts
@@ -1,0 +1,368 @@
+/**
+ * Process checkout: create Order + Order Items + Transaction from Cart.
+ * Phase 3 single-vendor: no sub-orders, no commission.
+ *
+ * All DB writes run in a single transaction when the adapter supports it (Postgres).
+ * MongoDB: beginTransaction may return null — operations run without a transaction (best-effort).
+ * Email is sent after commit. Used by process-checkout API and (future) payment webhooks.
+ */
+import type { Payload, PayloadRequest } from 'payload'
+import { NotFound } from 'payload'
+import { getDefaultCurrency } from './currencies'
+
+/** Creates req with transactionID when adapter supports transactions. */
+function reqWithTransaction(req: PayloadRequest | undefined, transactionID: string | number | null): PayloadRequest {
+  if (transactionID == null) return (req ?? {}) as PayloadRequest
+  const base = req ?? ({} as PayloadRequest)
+  return { ...base, transactionID }
+}
+
+export interface ProcessCheckoutInput {
+  /** Cart ID (UUID string or legacy number). Payload findByID accepts both. */
+  cartId: string | number
+  shippingAddress: {
+    firstName: string
+    lastName: string
+    street1: string
+    street2?: string
+    city: string
+    state?: string
+    postalCode?: string
+    country: string
+    phone?: string
+  }
+  billingAddress: {
+    firstName: string
+    lastName: string
+    street1: string
+    street2?: string
+    city: string
+    state?: string
+    postalCode?: string
+    country: string
+    phone?: string
+  }
+  /** Optional. Required for guest checkout. */
+  guestEmail?: string
+  /** Optional. For testing without real payment. */
+  simulatePayment?: boolean
+  /** Optional. Default from cart currency or platform default. */
+  currency?: string
+}
+
+export interface ProcessCheckoutResult {
+  /** IDs are strings (UUID standard). See docs/ID-STANDARD.md */
+  order: { id: string; orderNumber: string }
+  transaction?: { id: string }
+  error?: string
+  /** HTTP status when error is set (e.g. 404 for cart not found) */
+  statusCode?: number
+}
+
+export async function processCheckout(
+  payload: Payload,
+  input: ProcessCheckoutInput,
+  /** User ID. String with UUID; number with serial. Pass raw from req.user.id. */
+  userId?: string | number,
+  /** Request context for hooks (e.g. orders afterChange). Omit for webhooks. */
+  req?: PayloadRequest
+): Promise<ProcessCheckoutResult> {
+  const { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment = false } = input
+
+  // 1. Load cart with items (findByID throws NotFound if missing)
+  let cart: Awaited<ReturnType<Payload['findByID']>>
+  try {
+    cart = await payload.findByID({
+      collection: 'carts',
+      id: cartId,
+      depth: 2,
+    })
+  } catch (err) {
+    if (err instanceof NotFound) {
+      return { order: { id: '', orderNumber: '' }, error: 'Cart not found', statusCode: 404 }
+    }
+    throw err
+  }
+
+  const items = cart.items as Array<{
+    product: { id: string } | string
+    variant?: { id: string; name?: string; sku?: string } | string
+    quantity: number
+    unitPrice: number
+  }>
+
+  if (!items?.length) {
+    return { order: { id: '', orderNumber: '' }, error: 'Cart is empty' }
+  }
+
+  if (!userId && !guestEmail) {
+    return { order: { id: '', orderNumber: '' }, error: 'Guest checkout requires guestEmail' }
+  }
+
+  const currency = input.currency || getDefaultCurrency()
+
+  // 2. Compute order item data and subtotal
+  const orderItemData: Array<{
+    productId: string
+    variantId: string | null
+    productName: string
+    variantName: string
+    sku: string
+    quantity: number
+    unitPrice: number
+    totalPrice: number
+    productImage: string
+  }> = []
+  let subtotal = 0
+
+  for (const item of items) {
+    const productId = typeof item.product === 'object' ? item.product?.id : item.product
+    const variantId = item.variant ? (typeof item.variant === 'object' ? item.variant?.id : item.variant) : null
+
+    const product = await payload.findByID({
+      collection: 'products',
+      id: productId as string,
+      depth: 0,
+    })
+
+    if (!product) {
+      return { order: { id: '', orderNumber: '' }, error: `Product ${productId} not found` }
+    }
+
+    let variantName = ''
+    let sku = (product as { sku?: string }).sku || ''
+    let unitPrice = item.unitPrice
+
+    if (variantId) {
+      const variant = await payload.findByID({
+        collection: 'product-variants',
+        id: variantId as string,
+        depth: 0,
+      })
+      if (variant) {
+        variantName = (variant as { name?: string }).name || ''
+        sku = (variant as { sku?: string }).sku || sku
+        unitPrice = (variant as { price?: number }).price ?? unitPrice
+      }
+    } else {
+      unitPrice = (product as { basePrice?: number }).basePrice ?? unitPrice
+    }
+
+    const quantity = Number(item.quantity) || 1
+    const totalPrice = Math.round(quantity * unitPrice * 100) / 100
+    subtotal += totalPrice
+
+    orderItemData.push({
+      productId: productId as string,
+      variantId: variantId as string | null,
+      productName: (product as { name?: string }).name || 'Product',
+      variantName,
+      sku,
+      quantity,
+      unitPrice,
+      totalPrice,
+      productImage: '',
+    })
+  }
+
+  // 3. Calculate totals (Phase 3: simple - no shipping calc, no tax)
+  const shippingTotal = 0
+  const taxTotal = 0
+  const discountTotal = 0
+  const grandTotal = Math.round((subtotal + shippingTotal + taxTotal - discountTotal) * 100) / 100
+
+  const orderNumber = `ORD-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}-${Math.random().toString(36).substring(2, 6).toUpperCase()}`
+
+  const transactionID = await payload.db.beginTransaction()
+  const reqTx = reqWithTransaction(req, transactionID)
+
+  let order: { id: string | number; orderNumber?: string; status?: string }
+  let paymentTransactionId: string | undefined
+
+  try {
+    const orderData: Record<string, unknown> = {
+    orderNumber,
+    status: 'pending',
+    items: [],
+    shippingAddress,
+    billingAddress,
+    subtotal,
+    shippingTotal,
+    taxTotal,
+    discountTotal,
+    grandTotal,
+    currency,
+    paymentStatus: 'unpaid', // Set to paid in single update when simulatePayment (avoids inconsistent state)
+    notes: '',
+    placedAt: new Date().toISOString(),
+  }
+  if (userId) {
+    orderData.customer = userId
+  }
+    if (guestEmail) {
+      orderData.guestEmail = guestEmail
+    }
+
+    order = await payload.create({
+      collection: 'orders',
+      overrideAccess: true,
+      data: orderData as any,
+      req: reqTx,
+    })
+
+    const orderId = order.id as string
+
+    const historyData: Record<string, unknown> = {
+      order: orderId,
+      fromStatus: null,
+      toStatus: order.status || 'pending',
+      timestamp: new Date().toISOString(),
+    }
+    if (userId != null) historyData.changedBy = userId
+    await payload.create({
+      collection: 'order-status-history',
+      overrideAccess: true,
+      data: historyData as any,
+      req: reqTx,
+    })
+
+    const orderItemIds: string[] = []
+    for (const d of orderItemData) {
+      const itemData: Record<string, unknown> = {
+        order: orderId,
+        product: d.productId,
+        productName: d.productName,
+        variantName: d.variantName,
+        sku: d.sku,
+        quantity: d.quantity,
+        unitPrice: d.unitPrice,
+        totalPrice: d.totalPrice,
+        productImage: d.productImage,
+      }
+      if (d.variantId != null) {
+        itemData.variant = d.variantId
+      }
+
+      const orderItem = await payload.create({
+        collection: 'order-items',
+        overrideAccess: true,
+        data: itemData as any,
+        req: reqTx,
+      })
+      orderItemIds.push(orderItem.id as string)
+    }
+
+    const orderUpdateData: Record<string, unknown> = { items: orderItemIds }
+
+    const updateReq = { ...reqTx, context: { ...(reqTx.context || {}), skipOrderStatusHistory: simulatePayment } }
+    if (simulatePayment) {
+      const transaction = await payload.create({
+        collection: 'transactions',
+        overrideAccess: true,
+        data: {
+          order: order.id,
+          type: 'charge',
+          provider: 'test',
+          providerTransactionId: `test-${Date.now()}`,
+          amount: grandTotal,
+          currency,
+          status: 'succeeded',
+          metadata: { simulated: true },
+        },
+        req: reqTx,
+      })
+      paymentTransactionId = transaction.id as string
+      orderUpdateData.transaction = transaction.id
+      orderUpdateData.paymentStatus = 'paid'
+      orderUpdateData.status = 'processing'
+    }
+
+    const updatedOrder = await payload.update({
+      collection: 'orders',
+      id: order.id,
+      overrideAccess: true,
+      data: orderUpdateData as any,
+      req: updateReq,
+    })
+
+    if (simulatePayment && updatedOrder) {
+      const statusHistoryData: Record<string, unknown> = {
+        order: orderId,
+        fromStatus: 'pending',
+        toStatus: 'processing',
+        timestamp: new Date().toISOString(),
+      }
+      if (userId != null) statusHistoryData.changedBy = userId
+      await payload.create({
+        collection: 'order-status-history',
+        overrideAccess: true,
+        data: statusHistoryData as any,
+        req: reqTx,
+      })
+    }
+
+    const productIds = [...new Set(items.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[])]
+    const stockLevels = await payload.find({
+      collection: 'stock-levels',
+      where: productIds.length ? { product: { in: productIds } } : {},
+      limit: 100,
+      depth: 1,
+    })
+    for (const item of items) {
+      const productId = typeof item.product === 'object' ? item.product?.id : item.product
+      const variantId = item.variant ? (typeof item.variant === 'object' ? item.variant?.id : item.variant) : null
+      const quantity = Number((item as { quantity: number }).quantity) || 1
+
+      const level = stockLevels.docs.find((sl: any) => {
+        const slProduct = typeof sl.product === 'object' ? sl.product?.id : sl.product
+        const slVariant = typeof sl.variant === 'object' ? sl.variant?.id : sl.variant
+        return slProduct === productId && (variantId ? slVariant === variantId : !slVariant)
+      })
+      if (level) {
+        const reserved = Number((level as any).reservedQuantity) || 0
+        await payload.update({
+          collection: 'stock-levels',
+          id: level.id,
+          overrideAccess: true,
+          data: { reservedQuantity: reserved + quantity },
+          req: reqTx,
+        })
+      }
+    }
+
+    await payload.delete({
+      collection: 'carts',
+      id: cartId,
+      overrideAccess: true,
+      req: reqTx,
+    })
+
+    if (transactionID != null) {
+      await payload.db.commitTransaction(transactionID)
+    }
+  } catch (err) {
+    if (transactionID != null) {
+      await payload.db.rollbackTransaction(transactionID)
+    }
+    throw err
+  }
+
+  // Send order confirmation email (after commit; failure does not affect order)
+  let recipientEmail: string | undefined
+  if (guestEmail) recipientEmail = guestEmail
+  else if (userId) {
+    const user = await payload.findByID({ collection: 'users', id: userId, depth: 0 })
+    recipientEmail = (user as { email?: string })?.email
+  }
+  if (recipientEmail) {
+    const { sendOrderConfirmationEmail } = await import('../plugins/notifications/lib/send-email')
+    sendOrderConfirmationEmail(orderNumber, recipientEmail, grandTotal, currency).catch((e) =>
+      console.error('[processCheckout] Failed to send order email:', e)
+    )
+  }
+
+  return {
+    order: { id: order.id as string, orderNumber },
+    transaction: paymentTransactionId ? { id: paymentTransactionId } : undefined,
+  }
+}

--- a/packages/backend/src/lib/release-order-inventory.ts
+++ b/packages/backend/src/lib/release-order-inventory.ts
@@ -1,0 +1,68 @@
+/**
+ * Release reserved inventory when an order is cancelled or deleted.
+ * Decrements reservedQuantity on matching stock-levels (inverse of checkout reserve).
+ *
+ * Used by: Orders afterChange (status -> cancelled), Orders beforeDelete.
+ */
+import type { Payload, PayloadRequest } from 'payload'
+
+/** Minimal shape for order items (product, variant, quantity). Used by Orders hooks. */
+export type OrderItemLike = {
+  product?: string | { id: string }
+  variant?: string | { id: string } | null
+  quantity?: number
+}
+
+export async function releaseOrderInventory(
+  payload: Payload,
+  items: OrderItemLike[],
+  req?: PayloadRequest
+): Promise<void> {
+  if (!items?.length) return
+
+  const productIds = [...new Set(items.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[])]
+  if (!productIds.length) return
+
+  const stockLevels = await payload.find({
+    collection: 'stock-levels',
+    where: { product: { in: productIds } },
+    limit: 100,
+    depth: 1,
+  })
+
+  for (const item of items) {
+    if (!item.product) continue
+    const productId = typeof item.product === 'object' ? item.product?.id : item.product
+    const variantId = item.variant
+      ? typeof item.variant === 'object'
+        ? (item.variant as { id: string })?.id
+        : item.variant
+      : null
+    const quantity = Number(item.quantity) || 1
+
+    const level = (
+      stockLevels.docs as Array<{
+        id: string
+        product?: string | { id: string }
+        variant?: string | { id: string } | null
+        reservedQuantity?: number
+      }>
+    ).find((sl) => {
+      const slProduct = typeof sl.product === 'object' ? sl.product?.id : sl.product
+      const slVariant = typeof sl.variant === 'object' ? sl.variant?.id : sl.variant
+      return slProduct === productId && (variantId ? slVariant === variantId : !slVariant)
+    })
+
+    if (level) {
+      const reserved = Number(level.reservedQuantity) || 0
+      const newReserved = Math.max(0, reserved - quantity)
+      await payload.update({
+        collection: 'stock-levels',
+        id: level.id,
+        overrideAccess: true,
+        data: { reservedQuantity: newReserved },
+        ...(req && { req }),
+      })
+    }
+  }
+}

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -17,12 +17,17 @@ import { Categories } from './collections/categories'
 import { ecommercePlugin } from './plugins/ecommerce'
 import { inventoryPlugin } from './plugins/inventory'
 import { shippingPlugin } from './plugins/shipping'
+import { paymentsPlugin } from './plugins/payments'
+import { ordersPlugin } from './plugins/orders'
+import { notificationsPlugin } from './plugins/notifications'
 
 import { Header } from './globals/header'
 import { Footer } from './globals/footer'
 import { PlatformSettings } from './globals/platform-settings'
 
 import { redisConfig, cachedCollections } from './lib/redis'
+import { processCheckout } from './lib/process-checkout'
+import { authLoginEndpoint } from './endpoints/auth-login'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -37,6 +42,15 @@ export default buildConfig({
     meta: {
       titleSuffix: '— BS-Commerce Admin',
     },
+    components: {
+      views: {
+        'create-first-user': {
+          Component: '/components/CreateFirstUser',
+          path: '/create-first-user',
+          exact: true,
+        },
+      },
+    },
   },
 
   // ─── Editor ──────────────────────────────────────────────────────────────────
@@ -45,12 +59,16 @@ export default buildConfig({
   // ─── Database ────────────────────────────────────────────────────────────────
   // Default: Postgres via Drizzle ORM. Swap adapter to use MongoDB.
   // See: https://payloadcms.com/docs/database/postgres
+  //
+  // ID type: 'uuid' (default) = string IDs, DB-agnostic. 'serial' = integer IDs.
+  // See docs/ID-STANDARD.md. Use serial only for existing DBs with integer IDs.
   db: postgresAdapter({
+    idType: (process.env.DATABASE_ID_TYPE as 'serial' | 'uuid') || 'uuid',
     pool: {
       connectionString: process.env.DATABASE_URI!,
     },
   }),
-  // Alternative: MongoDB
+  // Alternative: MongoDB (uses string ObjectIds; no idType option)
   // db: mongooseAdapter({ url: process.env.DATABASE_URI! }),
 
   // ─── Localization ────────────────────────────────────────────────────────────
@@ -82,6 +100,62 @@ export default buildConfig({
   // ─── Globals ─────────────────────────────────────────────────────────────────
   globals: [Header, Footer, PlatformSettings],
 
+  // ─── Custom Endpoints ────────────────────────────────────────────────────────
+  endpoints: [
+    authLoginEndpoint,
+    {
+      path: '/checkout/process',
+      method: 'post',
+      handler: async (req) => {
+        const data = (await (req as Request).json?.().catch(() => ({}))) || {}
+        const { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment = false } = data
+
+        if (!cartId || !shippingAddress || !billingAddress) {
+          return Response.json(
+            { error: 'Missing required fields: cartId, shippingAddress, billingAddress' },
+            { status: 400 }
+          )
+        }
+
+        const requiredAddressFields = ['firstName', 'lastName', 'street1', 'city', 'country']
+        for (const field of requiredAddressFields) {
+          if (!shippingAddress[field]) {
+            return Response.json({ error: `shippingAddress.${field} is required` }, { status: 400 })
+          }
+          if (!billingAddress[field]) {
+            return Response.json({ error: `billingAddress.${field} is required` }, { status: 400 })
+          }
+        }
+
+        const userId = req.user?.id ?? undefined
+        if (!userId && !guestEmail) {
+          return Response.json(
+            { error: 'Guest checkout requires guestEmail in body' },
+            { status: 400 }
+          )
+        }
+
+        try {
+          const result = await processCheckout(
+            req.payload,
+            { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment },
+            userId,
+            req
+          )
+          if (result.error) {
+            const status = result.statusCode ?? 400
+            return Response.json({ error: result.error }, { status })
+          }
+          return Response.json(result, { status: 201 })
+        } catch (err) {
+          console.error('[checkout/process]', err)
+          const message = err instanceof Error ? err.message : 'Checkout failed'
+          return Response.json({ error: message }, { status: 500 })
+        }
+      },
+    },
+  ],
+
   // ─── Plugins ─────────────────────────────────────────────────────────────────
   // Order matters — dependencies must come first.
   // Phase 1: Redis cache only. Other plugins added in later phases.
@@ -109,6 +183,33 @@ export default buildConfig({
       model: (process.env.SHIPPING_MODEL || 'platform') as 'platform' | 'vendor' | 'hybrid',
     }),
 
+    // Phase 3: Payments & Orders
+    paymentsPlugin({
+      enabled: true,
+      adapter: (process.env.PAYMENT_PROVIDER || 'sslcommerz') as 'sslcommerz' | 'stripe',
+      sslcommerz: {
+        storeId: process.env.SSLCOMMERZ_STORE_ID,
+        storePassword: process.env.SSLCOMMERZ_STORE_PASSWORD,
+        sandbox: process.env.SSLCOMMERZ_SANDBOX === 'true',
+      },
+      stripe: {
+        secretKey: process.env.STRIPE_SECRET_KEY,
+        webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+      },
+    }),
+    ordersPlugin({
+      enabled: true,
+      splitByVendor: process.env.MULTIVENDOR_ENABLED === 'true',
+      orderStateMachine: 'default',
+    }),
+    notificationsPlugin({
+      enabled: true,
+      adapters: {
+        email: (process.env.EMAIL_ADAPTER as 'smtp' | 'resend') || 'smtp',
+        sms: process.env.SMS_ADAPTER,
+      },
+    }),
+
     // Future plugins (added per phase):
     // multivendorPlugin({ enabled: process.env.MULTIVENDOR_ENABLED === 'true', ... })
     // ecommercePlugin({ ... })
@@ -128,6 +229,10 @@ export default buildConfig({
   // Decision #18: email OR phone + password.
   // Decision #17: social login (Google + Facebook) via @papercup/payload-auth-plugin (Phase 1 prep).
   secret: process.env.PAYLOAD_SECRET!,
+  // RFC 6750: Bearer is the standard; Payload also supports JWT prefix. Prefer Bearer first.
+  auth: {
+    jwtOrder: ['Bearer', 'JWT', 'cookie'] as const,
+  },
 
   // ─── Sharp (image processing) ────────────────────────────────────────────────
   sharp,

--- a/packages/backend/src/plugins/ecommerce/collections/carts.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/carts.ts
@@ -1,5 +1,4 @@
 import type { CollectionConfig } from 'payload'
-import { isAdmin } from '../../../access/is-admin'
 
 export const Carts: CollectionConfig = {
   slug: 'carts',
@@ -10,22 +9,52 @@ export const Carts: CollectionConfig = {
   },
   hooks: {
     beforeChange: [
-      async ({ data, req }) => {
-        if (!data?.items || !Array.isArray(data.items)) return data
+      async ({ data, req, operation }) => {
+        if (!data) return data
 
+        // User assignment: customers can only create/update for self; admin can set any user.
+        if (req.user?.id != null) {
+          if (req.user.role !== 'admin') {
+            data.user = req.user.id // Customer/vendor: always use own ID, ignore any passed value
+          } else if (operation === 'create' && data.user == null) {
+            data.user = req.user.id // Admin create: default to self when not specified
+          }
+          // Admin update: allow explicit user (or leave unchanged if not in payload)
+        }
+
+        if (!data.items || !Array.isArray(data.items)) return data
+
+        // Derive unitPrice from product/variant — never trust client (OWASP: price manipulation)
         for (const item of data.items) {
           const variantId = typeof item.variant === 'object' ? item.variant?.id : item.variant
           const productId = typeof item.product === 'object' ? item.product?.id : item.product
-          if (variantId && productId) {
+          if (!productId) continue
+
+          const product = await req.payload.findByID({
+            collection: 'products',
+            id: productId,
+            depth: 0,
+          })
+          if (!product) throw new Error(`Product ${productId} not found`)
+
+          let unitPrice: number
+          if (variantId) {
             const variant = await req.payload.findByID({
               collection: 'product-variants',
               id: variantId,
+              depth: 0,
             })
             const vProductId = typeof variant?.product === 'object' ? variant?.product?.id : variant?.product
-            if (variant && vProductId !== productId) {
+            if (!variant || vProductId !== productId) {
               throw new Error(`Variant ${variantId} does not belong to product ${productId}`)
             }
+            unitPrice = Number((variant as { price?: number }).price)
+            if (isNaN(unitPrice) || unitPrice < 0) throw new Error(`Invalid variant price for ${variantId}`)
+          } else {
+            unitPrice = Number((product as { basePrice?: number }).basePrice)
+            if (isNaN(unitPrice) || unitPrice < 0) throw new Error(`Invalid product basePrice for ${productId}`)
           }
+          item.unitPrice = Math.round(unitPrice * 100) / 100
         }
 
         const subtotal = data.items.reduce(
@@ -72,7 +101,7 @@ export const Carts: CollectionConfig = {
     {
       name: 'items',
       type: 'array',
-      required: true,
+      required: false, // Allow empty cart after checkout; required=true would reject []
       defaultValue: [],
       fields: [
         {
@@ -87,7 +116,13 @@ export const Carts: CollectionConfig = {
           relationTo: 'product-variants',
         },
         { name: 'quantity', type: 'number', required: true, min: 1 },
-        { name: 'unitPrice', type: 'number', required: true, min: 0 },
+        {
+          name: 'unitPrice',
+          type: 'number',
+          required: false, // Server-populated from product/variant; client must not send
+          min: 0,
+          admin: { description: 'Auto-set from product basePrice or variant price. Do not send.' },
+        },
       ],
     },
     {

--- a/packages/backend/src/plugins/notifications/index.ts
+++ b/packages/backend/src/plugins/notifications/index.ts
@@ -1,0 +1,25 @@
+import type { Plugin } from 'payload'
+
+export interface NotificationsPluginOptions {
+  enabled?: boolean
+  adapters?: {
+    email?: 'smtp' | 'resend'
+    sms?: string
+  }
+}
+
+/**
+ * Basic notifications plugin.
+ * Phase 3: Sends order confirmation email on order creation.
+ * Uses console logging if no SMTP configured.
+ */
+export const notificationsPlugin =
+  (options: NotificationsPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    // Phase 3: no new collections. Hooks are registered via orders plugin.
+    // The sendOrderConfirmation is called from process-checkout.
+    return incomingConfig
+  }

--- a/packages/backend/src/plugins/notifications/lib/send-email.ts
+++ b/packages/backend/src/plugins/notifications/lib/send-email.ts
@@ -1,0 +1,37 @@
+/**
+ * Basic email sender for Phase 3.
+ * Logs to console if SMTP not configured.
+ * Replace with nodemailer/Resend in production.
+ */
+export interface SendEmailOptions {
+  to: string
+  subject: string
+  html?: string
+  text?: string
+}
+
+export async function sendEmail(options: SendEmailOptions): Promise<boolean> {
+  const { to, subject, html, text } = options
+  const smtpConfigured =
+    process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS
+
+  if (smtpConfigured) {
+    // TODO: Integrate nodemailer when SMTP env vars are set
+    console.log('[Notifications] SMTP configured but nodemailer not yet integrated. Logging email:')
+  }
+
+  console.log('[Notifications] Email:', { to, subject, preview: (text || html || '').slice(0, 100) })
+  return true
+}
+
+export async function sendOrderConfirmationEmail(
+  orderNumber: string,
+  recipientEmail: string,
+  grandTotal: number,
+  currency: string
+): Promise<boolean> {
+  const subject = `Order Confirmation: ${orderNumber}`
+  const text = `Thank you for your order ${orderNumber}. Total: ${currency} ${grandTotal}.`
+  const html = `<p>Thank you for your order <strong>${orderNumber}</strong>.</p><p>Total: ${currency} ${grandTotal}</p>`
+  return sendEmail({ to: recipientEmail, subject, html, text })
+}

--- a/packages/backend/src/plugins/orders/collections/order-items.ts
+++ b/packages/backend/src/plugins/orders/collections/order-items.ts
@@ -1,0 +1,65 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const OrderItems: CollectionConfig = {
+  slug: 'order-items',
+  admin: {
+    useAsTitle: 'productName',
+    defaultColumns: ['order', 'productName', 'variantName', 'quantity', 'unitPrice', 'totalPrice'],
+    group: 'Orders',
+    description: 'Line items for an order. Created at checkout from cart.',
+  },
+  access: {
+    create: isAdmin, // Only created via process-checkout, not by users directly
+    read: isAdmin, // Customers read via order
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'order',
+      type: 'relationship',
+      relationTo: 'orders',
+      required: true,
+      admin: { description: 'Parent order.' },
+    },
+    {
+      name: 'product',
+      type: 'relationship',
+      relationTo: 'products',
+      required: true,
+      admin: { description: 'Snapshot reference. Product may change later.' },
+    },
+    {
+      name: 'variant',
+      type: 'relationship',
+      relationTo: 'product-variants',
+      admin: { description: 'Variant if applicable.' },
+    },
+    {
+      name: 'productName',
+      type: 'text',
+      required: true,
+      admin: { description: 'Snapshot at time of purchase.' },
+    },
+    {
+      name: 'variantName',
+      type: 'text',
+      admin: { description: 'Snapshot at time of purchase.' },
+    },
+    {
+      name: 'sku',
+      type: 'text',
+      admin: { description: 'Snapshot at time of purchase.' },
+    },
+    { name: 'quantity', type: 'number', required: true, min: 1 },
+    { name: 'unitPrice', type: 'number', required: true, min: 0 },
+    { name: 'totalPrice', type: 'number', required: true, min: 0 },
+    {
+      name: 'productImage',
+      type: 'text',
+      admin: { description: 'Snapshot URL at time of purchase.' },
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/orders/collections/order-status-history.ts
+++ b/packages/backend/src/plugins/orders/collections/order-status-history.ts
@@ -1,0 +1,37 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const OrderStatusHistory: CollectionConfig = {
+  slug: 'order-status-history',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['order', 'fromStatus', 'toStatus', 'changedBy', 'timestamp'],
+    group: 'Orders',
+    description: 'Audit log of order status changes.',
+  },
+  access: {
+    create: isAdmin, // Only via hooks
+    read: isAdmin,
+    update: () => false, // Immutable
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'order',
+      type: 'relationship',
+      relationTo: 'orders',
+      required: true,
+    },
+    { name: 'fromStatus', type: 'text', admin: { description: 'Previous status.' } },
+    { name: 'toStatus', type: 'text', required: true },
+    {
+      name: 'changedBy',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: { description: 'User who changed the status.' },
+    },
+    { name: 'reason', type: 'textarea' },
+    { name: 'timestamp', type: 'date', required: true, defaultValue: () => new Date().toISOString() },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/orders/collections/orders.ts
+++ b/packages/backend/src/plugins/orders/collections/orders.ts
@@ -1,0 +1,213 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { isOrderOwnerOrAdmin } from '../../../access/is-order-owner-or-admin'
+import { getDefaultCurrency } from '../../../lib/currencies'
+import type { OrderItemLike } from '../../../lib/release-order-inventory'
+import { releaseOrderInventory } from '../../../lib/release-order-inventory'
+
+const addressGroupFields = [
+  { name: 'firstName', type: 'text' as const, required: true },
+  { name: 'lastName', type: 'text' as const, required: true },
+  { name: 'street1', type: 'text' as const, required: true },
+  { name: 'street2', type: 'text' as const },
+  { name: 'city', type: 'text' as const, required: true },
+  { name: 'state', type: 'text' as const },
+  { name: 'postalCode', type: 'text' as const },
+  { name: 'country', type: 'text' as const, required: true },
+  { name: 'phone', type: 'text' as const },
+]
+
+export const Orders: CollectionConfig = {
+  slug: 'orders',
+  admin: {
+    useAsTitle: 'orderNumber',
+    defaultColumns: ['orderNumber', 'customer', 'status', 'grandTotal', 'currency', 'placedAt'],
+    group: 'Orders',
+    description:
+      'Customer orders. Use status=Cancelled to cancel (releases inventory). Orders are never deleted (audit/tax).',
+  },
+  hooks: {
+    beforeDelete: [
+      async ({ id, req }) => {
+        const payload = req.payload
+        const orderId = id
+
+        const { docs: itemDocs } = await payload.find({
+          collection: 'order-items',
+          where: { order: { equals: orderId } },
+          limit: 1000,
+          depth: 1,
+        })
+        await releaseOrderInventory(payload, itemDocs as OrderItemLike[], req)
+
+        // Delete related records before order (FK constraints)
+        const { docs: historyDocs } = await payload.find({
+          collection: 'order-status-history',
+          where: { order: { equals: orderId } },
+          limit: 1000,
+          depth: 0,
+        })
+        for (const h of historyDocs) {
+          await payload.delete({ collection: 'order-status-history', id: h.id, overrideAccess: true, req })
+        }
+        const { docs: txDocs } = await payload.find({
+          collection: 'transactions',
+          where: { order: { equals: orderId } },
+          limit: 100,
+          depth: 0,
+        })
+        for (const tx of txDocs) {
+          await payload.delete({ collection: 'transactions', id: tx.id, overrideAccess: true, req })
+        }
+        for (const item of itemDocs) {
+          await payload.delete({ collection: 'order-items', id: item.id, overrideAccess: true, req })
+        }
+      },
+    ],
+    beforeChange: [
+      async ({ data, operation }) => {
+        if (operation === 'create' && data && !data.orderNumber) {
+          const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+          const suffix = Math.random().toString(36).substring(2, 6).toUpperCase()
+          data.orderNumber = `ORD-${date}-${suffix}`
+        }
+        return data
+      },
+    ],
+    afterChange: [
+      async ({ doc, previousDoc, operation, req }) => {
+        // Skip create: order-status-history for new orders is created in process-checkout
+        if (operation === 'create') return doc
+
+        const payload = req.payload
+        const orderId = doc.id
+        const fromStatus = previousDoc?.status ?? null
+        const toStatus = doc.status
+
+        // Release reserved inventory when order is cancelled (industry standard: cancel, don't delete)
+        if (toStatus === 'cancelled') {
+          const { docs: itemDocs } = await payload.find({
+            collection: 'order-items',
+            where: { order: { equals: orderId } },
+            limit: 1000,
+            depth: 1,
+          })
+          await releaseOrderInventory(payload, itemDocs as OrderItemLike[], req)
+        }
+
+        // process-checkout creates status-history when simulatePayment; skip to avoid nested create
+        if ((req as { context?: { skipOrderStatusHistory?: boolean } })?.context?.skipOrderStatusHistory) return doc
+        if (fromStatus && toStatus && fromStatus !== toStatus) {
+          const historyData: Record<string, unknown> = {
+            order: orderId,
+            fromStatus,
+            toStatus,
+            timestamp: new Date().toISOString(),
+          }
+          if (req.user?.id != null) historyData.changedBy = req.user.id
+          await payload.create({
+            collection: 'order-status-history',
+            overrideAccess: true,
+            data: historyData as any,
+            req,
+          })
+        }
+        return doc
+      },
+    ],
+  },
+  access: {
+    create: isAdmin, // Orders created via process-checkout (overrideAccess)
+    read: isOrderOwnerOrAdmin,
+    update: isAdmin,
+    // Industry standard: never delete orders (audit, tax, disputes). Use status=cancelled instead.
+    delete: () => false,
+  },
+  fields: [
+    {
+      name: 'orderNumber',
+      type: 'text',
+      required: true,
+      unique: true,
+      admin: { readOnly: true, description: 'Auto-generated e.g. ORD-20260225-XXXX.' },
+    },
+    {
+      name: 'customer',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: { description: 'Null for guest checkout.' },
+    },
+    {
+      name: 'guestEmail',
+      type: 'email',
+      admin: { description: 'For guest checkout.' },
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'pending',
+      options: [
+        { label: 'Pending', value: 'pending' },
+        { label: 'Processing', value: 'processing' },
+        { label: 'Partially Shipped', value: 'partially-shipped' },
+        { label: 'Shipped', value: 'shipped' },
+        { label: 'Delivered', value: 'delivered' },
+        { label: 'Completed', value: 'completed' },
+        { label: 'Cancelled', value: 'cancelled' },
+        { label: 'Refunded', value: 'refunded' },
+      ],
+    },
+    {
+      name: 'items',
+      type: 'relationship',
+      relationTo: 'order-items',
+      hasMany: true,
+      admin: { description: 'Order line items.' },
+    },
+    {
+      name: 'shippingAddress',
+      type: 'group',
+      required: true,
+      fields: addressGroupFields,
+    },
+    {
+      name: 'billingAddress',
+      type: 'group',
+      required: true,
+      fields: addressGroupFields,
+    },
+    { name: 'subtotal', type: 'number', required: true, defaultValue: 0 },
+    { name: 'shippingTotal', type: 'number', required: true, defaultValue: 0 },
+    { name: 'taxTotal', type: 'number', required: true, defaultValue: 0 },
+    { name: 'discountTotal', type: 'number', required: true, defaultValue: 0 },
+    { name: 'grandTotal', type: 'number', required: true, defaultValue: 0 },
+    {
+      name: 'currency',
+      type: 'text',
+      required: true,
+      defaultValue: () => getDefaultCurrency(),
+    },
+    {
+      name: 'paymentStatus',
+      type: 'select',
+      required: true,
+      defaultValue: 'unpaid',
+      options: [
+        { label: 'Unpaid', value: 'unpaid' },
+        { label: 'Paid', value: 'paid' },
+        { label: 'Partially Refunded', value: 'partially-refunded' },
+        { label: 'Refunded', value: 'refunded' },
+      ],
+    },
+    {
+      name: 'transaction',
+      type: 'relationship',
+      relationTo: 'transactions',
+      admin: { description: 'Primary payment transaction.' },
+    },
+    { name: 'notes', type: 'textarea', admin: { description: 'Customer notes.' } },
+    { name: 'placedAt', type: 'date', admin: { description: 'When order was placed.' } },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/orders/index.ts
+++ b/packages/backend/src/plugins/orders/index.ts
@@ -1,0 +1,27 @@
+import type { Plugin } from 'payload'
+import { Orders } from './collections/orders'
+import { OrderItems } from './collections/order-items'
+import { OrderStatusHistory } from './collections/order-status-history'
+
+export interface OrdersPluginOptions {
+  enabled?: boolean
+  splitByVendor?: boolean // Phase 5: sub-orders. Phase 3: false
+  orderStateMachine?: string
+}
+
+export const ordersPlugin =
+  (options: OrdersPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [
+        ...(incomingConfig.collections || []),
+        OrderItems,
+        OrderStatusHistory,
+        Orders,
+      ],
+    }
+  }

--- a/packages/backend/src/plugins/payments/collections/transactions.ts
+++ b/packages/backend/src/plugins/payments/collections/transactions.ts
@@ -1,0 +1,73 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const Transactions: CollectionConfig = {
+  slug: 'transactions',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['order', 'type', 'provider', 'amount', 'currency', 'status', 'createdAt'],
+    group: 'Payments',
+    description: 'Payment transactions. Created at checkout or refund.',
+  },
+  access: {
+    create: isAdmin, // Only via process-checkout or webhook
+    read: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'order',
+      type: 'relationship',
+      relationTo: 'orders',
+      required: true,
+    },
+    {
+      name: 'type',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Charge', value: 'charge' },
+        { label: 'Refund', value: 'refund' },
+        { label: 'Partial Refund', value: 'partial-refund' },
+      ],
+    },
+    {
+      name: 'provider',
+      type: 'text',
+      required: true,
+      admin: { description: 'e.g. sslcommerz, stripe.' },
+    },
+    {
+      name: 'providerTransactionId',
+      type: 'text',
+      admin: { description: 'Gateway transaction ID.' },
+    },
+    { name: 'amount', type: 'number', required: true, min: 0 },
+    { name: 'currency', type: 'text', required: true },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'pending',
+      options: [
+        { label: 'Pending', value: 'pending' },
+        { label: 'Processing', value: 'processing' },
+        { label: 'Succeeded', value: 'succeeded' },
+        { label: 'Failed', value: 'failed' },
+        { label: 'Cancelled', value: 'cancelled' },
+      ],
+    },
+    {
+      name: 'platformFee',
+      type: 'number',
+      admin: { description: 'Platform commission (multivendor).' },
+    },
+    {
+      name: 'metadata',
+      type: 'json',
+      admin: { description: 'Provider-specific data.' },
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/payments/index.ts
+++ b/packages/backend/src/plugins/payments/index.ts
@@ -1,0 +1,31 @@
+import type { Plugin } from 'payload'
+import { Transactions } from './collections/transactions'
+
+export interface PaymentsPluginOptions {
+  enabled?: boolean
+  adapter?: 'sslcommerz' | 'stripe'
+  sslcommerz?: {
+    storeId?: string
+    storePassword?: string
+    sandbox?: boolean
+  }
+  stripe?: {
+    secretKey?: string
+    webhookSecret?: string
+  }
+}
+
+export const paymentsPlugin =
+  (options: PaymentsPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [
+        ...(incomingConfig.collections || []),
+        Transactions,
+      ],
+    }
+  }


### PR DESCRIPTION
## Phase 3.0: Payments & Orders Core + Auth Enhancement

**Branch:** `feature/revamp-phase-3-payments-orders` → `revamp/multivendor`

---

### Phase 3.0 — Checkout & Orders

| Component | Description |
|-----------|-------------|
| **Checkout** | `POST /api/checkout/process` — cart → order + items + transaction |
| **Orders** | Order, OrderItems, OrderStatusHistory collections |
| **Transactions** | Payments collection, `simulatePayment` for testing |
| **Atomicity** | Postgres transaction; MongoDB fallback when no transaction support |
| **Inventory** | Reserve on checkout; release on cancel/delete |
| **Guest checkout** | `guestEmail` in process payload |
| **Notifications** | `sendOrderConfirmationEmail()` called (delivery in 3.3/3.4) |

---

### Auth Enhancement

| Feature | Description |
|---------|-------------|
| **Identifier** | Registration and login with email OR phone |
| **Config** | `AUTH_REQUIRED_IDENTIFIER`: `email` \| `phone` \| `either` |
| **Login** | `POST /api/auth/login` with single `identifier` + `password` |
| **Username** | `username = phone \|\| email` for dual-login when both exist |
| **Verification** | `emailVerified` / `phoneVerified` reset when identifier changes |
| **Admin create** | Username hidden on create, shown on edit |

---

### Custom Create-First-User

Built-in form fails validation (email, username). Custom view:
- Uses `POST /api/users` instead of `first-register`
- Fields by `NEXT_PUBLIC_AUTH_REQUIRED_IDENTIFIER` (email-only, phone-only, or both)
- Full-width Create button
- Sets `role: admin`, `status: active`

---

### Environment Variables

AUTH_REQUIRED_IDENTIFIER=either
NEXT_PUBLIC_AUTH_REQUIRED_IDENTIFIER=either
