### PR TITLE
feat(multivendor): Phase 4 — Multivendor Foundation

### DIFF
--- a/packages/backend/src/collections/categories.ts
+++ b/packages/backend/src/collections/categories.ts
@@ -1,0 +1,92 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../access/is-admin'
+import { slugField } from '../fields/slug'
+
+export const Categories: CollectionConfig = {
+  slug: 'categories',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'slug', 'parent', 'isActive', 'displayOrder'],
+    group: 'Catalog',
+  },
+  access: {
+    create: isAdmin,
+    read: () => true,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      localized: true,
+    },
+    slugField('name'),
+    {
+      name: 'description',
+      type: 'richText',
+      localized: true,
+    },
+    {
+      name: 'image',
+      type: 'upload',
+      relationTo: 'media',
+    },
+    {
+      name: 'parent',
+      type: 'relationship',
+      relationTo: 'categories',
+      hasMany: false,
+      admin: {
+        description: 'Leave empty for top-level categories.',
+      },
+    },
+    {
+      name: 'displayOrder',
+      type: 'number',
+      defaultValue: 0,
+      admin: {
+        description: 'Lower numbers appear first.',
+      },
+    },
+    {
+      name: 'isActive',
+      type: 'checkbox',
+      defaultValue: true,
+    },
+    {
+      name: 'commissionOverride',
+      type: 'number',
+      min: 0,
+      max: 100,
+      admin: {
+        description: 'Optional: override default platform commission % for products in this category.',
+        step: 0.01,
+      },
+    },
+    // SEO fields (inline — SEO plugin will be added later)
+    {
+      name: 'meta',
+      type: 'group',
+      label: 'SEO',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+          localized: true,
+        },
+        {
+          name: 'image',
+          type: 'upload',
+          relationTo: 'media',
+        },
+      ],
+    },
+  ],
+}

--- a/packages/backend/src/collections/media.ts
+++ b/packages/backend/src/collections/media.ts
@@ -1,0 +1,52 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../access/is-admin'
+
+export const Media: CollectionConfig = {
+  slug: 'media',
+  upload: {
+    staticDir: 'media',
+    imageSizes: [
+      {
+        name: 'thumbnail',
+        width: 400,
+        height: 300,
+        position: 'centre',
+      },
+      {
+        name: 'card',
+        width: 768,
+        height: 1024,
+        position: 'centre',
+      },
+      {
+        name: 'tablet',
+        width: 1024,
+        height: undefined,
+        position: 'centre',
+      },
+    ],
+    adminThumbnail: 'thumbnail',
+    mimeTypes: ['image/*', 'application/pdf'],
+  },
+  admin: {
+    group: 'Platform',
+  },
+  access: {
+    create: ({ req }) => Boolean(req.user),
+    read: () => true,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'alt',
+      type: 'text',
+      localized: true,
+    },
+    {
+      name: 'caption',
+      type: 'text',
+      localized: true,
+    },
+  ],
+}

--- a/packages/backend/src/collections/pages.ts
+++ b/packages/backend/src/collections/pages.ts
@@ -1,0 +1,152 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../access/is-admin'
+import { slugField } from '../fields/slug'
+
+export const Pages: CollectionConfig = {
+  slug: 'pages',
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'slug', 'status', 'updatedAt'],
+    preview: (doc) => {
+      const slug = doc?.slug as string | undefined
+      if (!slug) return null
+      const baseUrl = process.env.NEXT_PUBLIC_STOREFRONT_URL || 'http://localhost:3001'
+      return `${baseUrl}/en/${slug}`
+    },
+    group: 'Content',
+  },
+  access: {
+    create: isAdmin,
+    read: ({ req }) => {
+      if (req.user?.role === 'admin') return true
+      return {
+        status: {
+          equals: 'published',
+        },
+      }
+    },
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+      localized: true,
+    },
+    slugField('title'),
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'draft',
+      options: [
+        { label: 'Draft', value: 'draft' },
+        { label: 'Published', value: 'published' },
+      ],
+      admin: {
+        position: 'sidebar',
+      },
+    },
+    {
+      name: 'layout',
+      type: 'blocks',
+      localized: true,
+      blocks: [
+        {
+          slug: 'richText',
+          labels: {
+            singular: 'Rich Text Block',
+            plural: 'Rich Text Blocks',
+          },
+          fields: [
+            {
+              name: 'content',
+              type: 'richText',
+            },
+          ],
+        },
+        {
+          slug: 'hero',
+          labels: {
+            singular: 'Hero Block',
+            plural: 'Hero Blocks',
+          },
+          fields: [
+            {
+              name: 'heading',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'subheading',
+              type: 'textarea',
+              localized: true,
+            },
+            {
+              name: 'backgroundImage',
+              type: 'upload',
+              relationTo: 'media',
+            },
+            {
+              name: 'ctaLabel',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'ctaUrl',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    },
+    // SEO
+    {
+      name: 'meta',
+      type: 'group',
+      label: 'SEO',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+          localized: true,
+        },
+        {
+          name: 'image',
+          type: 'upload',
+          relationTo: 'media',
+        },
+      ],
+    },
+    {
+      name: 'publishedAt',
+      type: 'date',
+      admin: {
+        position: 'sidebar',
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+    },
+  ],
+  hooks: {
+    beforeChange: [
+      ({ data }) => {
+        if (data.status === 'published' && !data.publishedAt) {
+          return { ...data, publishedAt: new Date().toISOString() }
+        }
+        return data
+      },
+    ],
+  },
+}

--- a/packages/backend/src/collections/users/index.ts
+++ b/packages/backend/src/collections/users/index.ts
@@ -146,7 +146,7 @@ export const Users: CollectionConfig = {
       ],
     },
 
-    // tenant field added in Phase 4 (multivendor plugin — tenants collection)
+    // tenant field added by multivendor plugin when MULTIVENDOR_ENABLED=true
     {
       name: 'addresses',
       type: 'relationship',

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -15,6 +15,7 @@ import { Pages } from './collections/pages'
 import { Categories } from './collections/categories'
 
 import { ecommercePlugin } from './plugins/ecommerce'
+import { multivendorPlugin } from './plugins/multivendor'
 import { inventoryPlugin } from './plugins/inventory'
 import { shippingPlugin } from './plugins/shipping'
 import { paymentsPlugin } from './plugins/payments'
@@ -166,9 +167,18 @@ export default buildConfig({
       collections: cachedCollections,
     }),
 
+    // Phase 4: Multivendor Foundation (must run before ecommerce for tenant field on Users)
+    multivendorPlugin({
+      enabled: process.env.MULTIVENDOR_ENABLED === 'true',
+      autoApproveVendors: process.env.VENDOR_AUTO_APPROVE === 'true',
+      requireKYC: process.env.VENDOR_KYC_REQUIRED === 'true',
+      requireProductApproval: process.env.PRODUCT_REQUIRES_APPROVAL === 'true',
+    }),
+
     // Phase 2: Ecommerce Core
     ecommercePlugin({
       enabled: true,
+      multivendorEnabled: process.env.MULTIVENDOR_ENABLED === 'true',
       currencies: (process.env.SUPPORTED_CURRENCIES || 'USD,BDT').split(','),
       defaultCurrency: process.env.DEFAULT_CURRENCY || 'USD',
       allowGuestCheckout: process.env.GUEST_CHECKOUT_ENABLED === 'true',
@@ -211,7 +221,6 @@ export default buildConfig({
     }),
 
     // Future plugins (added per phase):
-    // multivendorPlugin({ enabled: process.env.MULTIVENDOR_ENABLED === 'true', ... })
     // ecommercePlugin({ ... })
     // ordersPlugin({ ... })
     // paymentsPlugin({ ... })

--- a/packages/backend/src/plugins/ecommerce/collections/product-variants.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/product-variants.ts
@@ -1,24 +1,9 @@
 import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
 
-export const ProductVariants: CollectionConfig = {
-  slug: 'product-variants',
-  admin: {
-    useAsTitle: 'name',
-    defaultColumns: ['name', 'sku', 'price', 'product', 'isActive'],
-    group: 'Ecommerce',
-  },
-  access: {
-    create: isAdmin,
-    read: ({ req }) => {
-      if (!req.user) return { isActive: { equals: true } }
-      if (req.user.role === 'admin') return true
-      return { isActive: { equals: true } }
-    },
-    update: isAdmin,
-    delete: isAdmin,
-  },
-  fields: [
+export function createProductVariantsConfig(multivendorEnabled = false): CollectionConfig {
+  const fields: CollectionConfig['fields'] = [
     {
       name: 'product',
       type: 'relationship',
@@ -44,6 +29,63 @@ export const ProductVariants: CollectionConfig = {
     },
     { name: 'weight', type: 'number', min: 0 },
     { name: 'isActive', type: 'checkbox', defaultValue: true },
-  ],
-  timestamps: true,
+  ]
+
+  if (multivendorEnabled) {
+    fields.splice(1, 0, {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      required: true,
+      admin: { description: 'Inherited from product. Auto-set on save.' },
+    })
+  }
+
+  return {
+    slug: 'product-variants',
+    admin: {
+      useAsTitle: 'name',
+      defaultColumns: multivendorEnabled
+        ? ['name', 'sku', 'price', 'product', 'tenant', 'isActive']
+        : ['name', 'sku', 'price', 'product', 'isActive'],
+      group: 'Ecommerce',
+    },
+    access: {
+      create: multivendorEnabled ? isAdminOrVendorOwner : isAdmin,
+      read: ({ req }) => {
+        if (!req.user) return { isActive: { equals: true } }
+        if (req.user.role === 'admin') return true
+        if (multivendorEnabled && req.user.role === 'vendor') return isAdminOrVendorOwner({ req })
+        return { isActive: { equals: true } }
+      },
+      update: multivendorEnabled ? isAdminOrVendorOwner : isAdmin,
+      delete: multivendorEnabled ? isAdminOrVendorOwner : isAdmin,
+    },
+    hooks: multivendorEnabled
+      ? {
+          beforeValidate: [
+            async ({ data, req }) => {
+              if (!data) return data
+              if (!data.tenant && data.product) {
+                const productId = typeof data.product === 'object' ? (data.product as { id?: string }).id : data.product
+                if (productId && req.payload) {
+                  const p = await req.payload.findByID({ collection: 'products', id: productId, depth: 0 })
+                  if (p?.tenant) data.tenant = typeof p.tenant === 'object' ? (p.tenant as { id: string }).id : p.tenant
+                }
+              }
+              if (req.user?.role === 'vendor' && req.user.tenant && !data.tenant) {
+                const tenantId = typeof req.user.tenant === 'object' ? req.user.tenant.id : req.user.tenant
+                data.tenant = tenantId
+              }
+              return data
+            },
+          ],
+        }
+      : undefined,
+    fields,
+    timestamps: true,
+  }
 }
+
+/** @deprecated Use createProductVariantsConfig(multivendorEnabled) */
+export const ProductVariants: CollectionConfig = createProductVariantsConfig(false)

--- a/packages/backend/src/plugins/ecommerce/collections/products.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/products.ts
@@ -1,26 +1,11 @@
 import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
 import { slugField } from '../../../fields/slug'
 import { getCurrencyOptions } from '../../../lib/currencies'
 
-export const Products: CollectionConfig = {
-  slug: 'products',
-  admin: {
-    useAsTitle: 'name',
-    defaultColumns: ['name', 'slug', 'status', 'basePrice', 'currency', 'publishedAt'],
-    group: 'Ecommerce',
-  },
-  access: {
-    create: isAdmin,
-    read: ({ req }) => {
-      if (!req.user) return { status: { equals: 'published' } }
-      if (req.user.role === 'admin') return true
-      return { status: { equals: 'published' } }
-    },
-    update: isAdmin,
-    delete: isAdmin,
-  },
-  fields: [
+export function createProductsConfig(multivendorEnabled = false): CollectionConfig {
+  const fields: CollectionConfig['fields'] = [
     { name: 'name', type: 'text', required: true, localized: true },
     slugField('name'),
     {
@@ -103,6 +88,56 @@ export const Products: CollectionConfig = {
       ],
     },
     { name: 'publishedAt', type: 'date' },
-  ],
-  timestamps: true,
+  ]
+
+  if (multivendorEnabled) {
+    fields.unshift({
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      required: true,
+      admin: { description: 'Vendor (tenant) who owns this product.' },
+    })
+  }
+
+  return {
+    slug: 'products',
+    admin: {
+      useAsTitle: 'name',
+      defaultColumns: multivendorEnabled
+        ? ['name', 'slug', 'tenant', 'status', 'basePrice', 'currency', 'publishedAt']
+        : ['name', 'slug', 'status', 'basePrice', 'currency', 'publishedAt'],
+      group: 'Ecommerce',
+    },
+    access: {
+      create: multivendorEnabled ? isAdminOrVendorOwner : isAdmin,
+      read: ({ req }) => {
+        if (!req.user) return { status: { equals: 'published' } }
+        if (req.user.role === 'admin') return true
+        if (multivendorEnabled && req.user.role === 'vendor') return isAdminOrVendorOwner({ req })
+        return { status: { equals: 'published' } }
+      },
+      update: multivendorEnabled ? isAdminOrVendorOwner : isAdmin,
+      delete: multivendorEnabled ? isAdminOrVendorOwner : isAdmin,
+    },
+    hooks: multivendorEnabled
+      ? {
+          beforeValidate: [
+            ({ data, req }) => {
+              if (!data) return data
+              if (req.user?.role === 'vendor' && req.user.tenant && !data.tenant) {
+                const tenantId = typeof req.user.tenant === 'object' ? req.user.tenant.id : req.user.tenant
+                data.tenant = tenantId
+              }
+              return data
+            },
+          ],
+        }
+      : undefined,
+    fields,
+    timestamps: true,
+  }
 }
+
+/** @deprecated Use createProductsConfig(multivendorEnabled) */
+export const Products: CollectionConfig = createProductsConfig(false)

--- a/packages/backend/src/plugins/ecommerce/index.ts
+++ b/packages/backend/src/plugins/ecommerce/index.ts
@@ -1,11 +1,12 @@
 import type { Plugin } from 'payload'
-import { Products } from './collections/products'
-import { ProductVariants } from './collections/product-variants'
+import { createProductsConfig } from './collections/products'
+import { createProductVariantsConfig } from './collections/product-variants'
 import { Carts } from './collections/carts'
 import { Addresses } from './collections/addresses'
 
 export interface EcommercePluginOptions {
   enabled?: boolean
+  multivendorEnabled?: boolean
   currencies?: string[]
   defaultCurrency?: string
   allowGuestCheckout?: boolean
@@ -14,15 +15,15 @@ export interface EcommercePluginOptions {
 export const ecommercePlugin =
   (options: EcommercePluginOptions = {}): Plugin =>
   (incomingConfig) => {
-    const { enabled = true } = options
+    const { enabled = true, multivendorEnabled = false } = options
     if (!enabled) return incomingConfig
 
     return {
       ...incomingConfig,
       collections: [
         ...(incomingConfig.collections || []),
-        Products,
-        ProductVariants,
+        createProductsConfig(multivendorEnabled),
+        createProductVariantsConfig(multivendorEnabled),
         Carts,
         Addresses,
       ],

--- a/packages/backend/src/plugins/multivendor/collections/tenants.ts
+++ b/packages/backend/src/plugins/multivendor/collections/tenants.ts
@@ -1,0 +1,37 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { slugField } from '../../../fields/slug'
+
+/**
+ * Tenants = Vendors. Each vendor is a tenant.
+ * Used for tenant-scoped data isolation (products, orders, media).
+ */
+export const Tenants: CollectionConfig = {
+  slug: 'tenants',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'slug', 'createdAt'],
+    group: 'Multivendor',
+    description: 'Vendors (tenants). Each vendor has a tenant record for data isolation.',
+  },
+  access: {
+    create: isAdmin,
+    read: ({ req }) => {
+      if (!req.user) return false
+      if (req.user.role === 'admin') return true
+      // Vendor: can only read their own tenant
+      if (req.user.role === 'vendor' && req.user.tenant) {
+        const tenantId = typeof req.user.tenant === 'object' ? req.user.tenant.id : req.user.tenant
+        return { id: { equals: tenantId } }
+      }
+      return false
+    },
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    slugField('name'),
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/multivendor/collections/vendor-applications.ts
+++ b/packages/backend/src/plugins/multivendor/collections/vendor-applications.ts
@@ -1,0 +1,198 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { slugify } from '@bs-commerce/shared'
+
+/**
+ * Vendor Applications — onboarding workflow.
+ * When approved: creates Tenant, VendorProfile, VendorSettings; updates User.
+ */
+export const VendorApplications: CollectionConfig = {
+  slug: 'vendor-applications',
+  admin: {
+    useAsTitle: 'businessName',
+    defaultColumns: ['businessName', 'applicant', 'status', 'submittedAt', 'reviewedAt'],
+    group: 'Multivendor',
+    description: 'Vendor onboarding applications. Approve to create vendor tenant.',
+  },
+  access: {
+    create: ({ req }) => Boolean(req.user),
+    read: ({ req }) => {
+      if (!req.user) return false
+      if (req.user.role === 'admin') return true
+      // Vendor/applicant: only their own applications
+      return { applicant: { equals: req.user.id } }
+    },
+    update: ({ req }) => {
+      if (!req.user) return false
+      if (req.user.role === 'admin') return true
+      // Applicant can update only pending applications (e.g. withdraw)
+      return {
+        applicant: { equals: req.user.id },
+        status: { equals: 'pending' },
+      }
+    },
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'applicant',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+      admin: {
+        description: 'Auto-set when customer applies. Admin selects when creating on behalf of a customer.',
+        condition: (_, __, { user }) => user?.role === 'admin',
+      },
+    },
+    { name: 'businessName', type: 'text', required: true },
+    {
+      name: 'businessType',
+      type: 'select',
+      options: [
+        { label: 'Individual', value: 'individual' },
+        { label: 'Company', value: 'company' },
+        { label: 'Partnership', value: 'partnership' },
+      ],
+    },
+    { name: 'taxId', type: 'text' },
+    {
+      name: 'documents',
+      type: 'array',
+      fields: [
+        {
+          name: 'document',
+          type: 'upload',
+          relationTo: 'media',
+          required: true,
+        },
+      ],
+      admin: { description: 'KYC documents for verification.' },
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'pending',
+      options: [
+        { label: 'Pending', value: 'pending' },
+        { label: 'Under Review', value: 'under-review' },
+        { label: 'Approved', value: 'approved' },
+        { label: 'Rejected', value: 'rejected' },
+      ],
+    },
+    {
+      name: 'reviewedBy',
+      type: 'relationship',
+      relationTo: 'users',
+    },
+    { name: 'reviewNotes', type: 'textarea' },
+    { name: 'rejectionReason', type: 'text' },
+    { name: 'submittedAt', type: 'date' },
+    { name: 'reviewedAt', type: 'date' },
+  ],
+  hooks: {
+    beforeValidate: [
+      ({ data, operation, req }) => {
+        if (!data) return data
+        if (operation === 'create' && req.user) {
+          if (req.user.role !== 'admin') {
+            data.applicant = req.user.id
+          }
+          data.submittedAt = data.submittedAt ?? new Date()
+          if (process.env.VENDOR_AUTO_APPROVE === 'true') {
+            data.status = 'approved'
+          }
+        }
+        return data
+      },
+    ],
+    afterChange: [
+      async ({ doc, previousDoc, operation, req }) => {
+        if (!req.payload) return
+
+        const status = typeof doc.status === 'string' ? doc.status : doc.status?.value ?? doc.status
+        const prevStatus =
+          previousDoc && (typeof previousDoc.status === 'string'
+            ? previousDoc.status
+            : (previousDoc.status as { value?: string })?.value ?? previousDoc.status)
+
+        if (status !== 'approved' || (operation === 'update' && prevStatus === 'approved')) {
+          return
+        }
+
+        const applicantId = typeof doc.applicant === 'object' ? doc.applicant?.id : doc.applicant
+        if (!applicantId) return
+
+        const businessName =
+          typeof doc.businessName === 'string' ? doc.businessName : String(doc.businessName ?? '')
+        if (!businessName.trim()) return
+
+        // Ensure unique slug for tenant
+        let baseSlug = slugify(businessName) || 'vendor'
+        let slug = baseSlug
+        let suffix = 0
+        while (true) {
+          const { docs } = await req.payload.find({
+            collection: 'tenants',
+            where: { slug: { equals: slug } },
+            limit: 1,
+          })
+          if (docs.length === 0) break
+          suffix += 1
+          slug = `${baseSlug}-${suffix}`
+        }
+
+        const tenant = await req.payload.create({
+          collection: 'tenants',
+          data: { name: businessName.trim(), slug },
+          req,
+          overrideAccess: true,
+        })
+
+        const tenantId = typeof tenant.id === 'string' ? tenant.id : String(tenant.id)
+
+        await req.payload.create({
+          collection: 'vendor-profiles',
+          data: {
+            tenant: tenantId,
+            displayName: businessName.trim(),
+            joinedAt: new Date(),
+          },
+          req,
+          overrideAccess: true,
+        })
+
+        await req.payload.create({
+          collection: 'vendor-settings',
+          data: {
+            tenant: tenantId,
+            isActive: true,
+            autoPublishProducts: true,
+          },
+          req,
+          overrideAccess: true,
+        })
+
+        await req.payload.update({
+          collection: 'users',
+          id: applicantId,
+          data: {
+            role: 'vendor',
+            tenant: tenantId,
+          },
+          req,
+          overrideAccess: true,
+        })
+
+        await req.payload.update({
+          collection: 'vendor-applications',
+          id: doc.id,
+          data: { reviewedAt: new Date() },
+          req,
+          overrideAccess: true,
+        })
+      },
+    ],
+  },
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/multivendor/collections/vendor-profiles.ts
+++ b/packages/backend/src/plugins/multivendor/collections/vendor-profiles.ts
@@ -1,0 +1,102 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
+
+/**
+ * Vendor Profiles — public-facing store page at /store/[vendor-slug].
+ * One-to-one with Tenants.
+ */
+export const VendorProfiles: CollectionConfig = {
+  slug: 'vendor-profiles',
+  admin: {
+    useAsTitle: 'displayName',
+    defaultColumns: ['displayName', 'tenant', 'rating', 'totalSales', 'joinedAt'],
+    group: 'Multivendor',
+    description: 'Public vendor store profiles. Shown at /store/[vendor-slug].',
+  },
+  access: {
+    create: isAdmin,
+    read: ({ req }) => {
+      // Guest/customer: read published profiles (all are public when approved)
+      if (!req.user) return true
+      if (req.user.role === 'admin') return true
+      if (req.user.role === 'vendor') return isAdminOrVendorOwner({ req })
+      // Customer: read all (public directory)
+      return true
+    },
+    update: isAdminOrVendorOwner,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      required: true,
+      unique: true,
+      admin: { description: 'The vendor (tenant) this profile belongs to.' },
+    },
+    { name: 'displayName', type: 'text', required: true, localized: true },
+    {
+      name: 'description',
+      type: 'richText',
+      localized: true,
+    },
+    {
+      name: 'logo',
+      type: 'upload',
+      relationTo: 'media',
+    },
+    {
+      name: 'banner',
+      type: 'upload',
+      relationTo: 'media',
+    },
+    { name: 'contactEmail', type: 'email' },
+    { name: 'contactPhone', type: 'text' },
+    { name: 'website', type: 'text' },
+    {
+      name: 'socialLinks',
+      type: 'array',
+      fields: [
+        { name: 'platform', type: 'text', required: true },
+        { name: 'url', type: 'text', required: true },
+      ],
+    },
+    {
+      name: 'address',
+      type: 'group',
+      fields: [
+        { name: 'street', type: 'text' },
+        { name: 'city', type: 'text' },
+        { name: 'state', type: 'text' },
+        { name: 'country', type: 'text' },
+        { name: 'zip', type: 'text' },
+      ],
+    },
+    {
+      name: 'rating',
+      type: 'number',
+      admin: { description: 'Aggregated from vendor reviews (Phase 6).', readOnly: true },
+      defaultValue: 0,
+    },
+    {
+      name: 'totalSales',
+      type: 'number',
+      admin: { description: 'Denormalized sales counter.', readOnly: true },
+      defaultValue: 0,
+    },
+    { name: 'joinedAt', type: 'date' },
+    {
+      name: 'meta',
+      type: 'group',
+      label: 'SEO',
+      fields: [
+        { name: 'title', type: 'text', localized: true },
+        { name: 'description', type: 'textarea', localized: true },
+        { name: 'image', type: 'upload', relationTo: 'media' },
+      ],
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/multivendor/collections/vendor-settings.ts
+++ b/packages/backend/src/plugins/multivendor/collections/vendor-settings.ts
@@ -1,0 +1,100 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
+
+/**
+ * Vendor Settings — one per tenant (enforced by unique tenant).
+ * Overrides platform defaults (commission, payout, shipping).
+ */
+export const VendorSettings: CollectionConfig = {
+  slug: 'vendor-settings',
+  admin: {
+    useAsTitle: 'tenant',
+    defaultColumns: ['tenant', 'commissionRate', 'isActive', 'updatedAt'],
+    group: 'Multivendor',
+    description: 'Per-vendor settings. One record per tenant.',
+  },
+  access: {
+    create: isAdmin,
+    read: isAdminOrVendorOwner,
+    update: isAdminOrVendorOwner,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      required: true,
+      unique: true,
+      admin: { description: 'One settings record per vendor.' },
+    },
+    {
+      name: 'commissionRate',
+      type: 'number',
+      min: 0,
+      max: 100,
+      admin: { description: 'Override default platform commission %.' },
+    },
+    {
+      name: 'commissionType',
+      type: 'select',
+      options: [
+        { label: 'Percentage', value: 'percentage' },
+        { label: 'Flat', value: 'flat' },
+        { label: 'Tiered', value: 'tiered' },
+      ],
+      admin: { description: 'Override default strategy.' },
+    },
+    {
+      name: 'payoutMethod',
+      type: 'select',
+      options: [
+        { label: 'Stripe', value: 'stripe' },
+        { label: 'Bank Transfer', value: 'bank-transfer' },
+        { label: 'Manual', value: 'manual' },
+      ],
+    },
+    { name: 'stripeConnectAccountId', type: 'text' },
+    {
+      name: 'bankDetails',
+      type: 'group',
+      fields: [
+        { name: 'bankName', type: 'text' },
+        { name: 'accountNumber', type: 'text' },
+        { name: 'routingNumber', type: 'text' },
+        { name: 'iban', type: 'text' },
+      ],
+    },
+    {
+      name: 'shippingModel',
+      type: 'select',
+      options: [
+        { label: 'Platform', value: 'platform' },
+        { label: 'Vendor', value: 'vendor' },
+        { label: 'Hybrid', value: 'hybrid' },
+      ],
+      admin: { description: 'Override default shipping model.' },
+    },
+    {
+      name: 'autoPublishProducts',
+      type: 'checkbox',
+      defaultValue: true,
+      admin: { description: 'If false, products start as draft.' },
+    },
+    {
+      name: 'maxProducts',
+      type: 'number',
+      min: 0,
+      admin: { description: '0 = unlimited.' },
+    },
+    {
+      name: 'isActive',
+      type: 'checkbox',
+      defaultValue: true,
+      admin: { description: 'Admin can deactivate vendor.' },
+    },
+    { name: 'suspensionReason', type: 'textarea' },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/multivendor/index.ts
+++ b/packages/backend/src/plugins/multivendor/index.ts
@@ -1,0 +1,115 @@
+import type { Plugin } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { isAdminOrVendorOwner } from '../../access/is-admin-or-vendor-owner'
+import { Tenants } from './collections/tenants'
+import { VendorProfiles } from './collections/vendor-profiles'
+import { VendorSettings } from './collections/vendor-settings'
+import { VendorApplications } from './collections/vendor-applications'
+
+export interface MultivendorPluginOptions {
+  enabled?: boolean
+  autoApproveVendors?: boolean
+  requireKYC?: boolean
+  requireProductApproval?: boolean
+}
+
+const tenantField = {
+  name: 'tenant',
+  type: 'relationship' as const,
+  relationTo: 'tenants',
+  admin: {
+    description: 'Vendor tenant. Set when user becomes a vendor (approved application).',
+  },
+}
+
+/**
+ * Multivendor plugin — Tenants, VendorProfiles, VendorSettings, VendorApplications.
+ * Adds tenant field to Users when enabled.
+ * When disabled (MULTIVENDOR_ENABLED=false), no collections are registered.
+ */
+export const multivendorPlugin =
+  (options: MultivendorPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = false } = options
+    if (!enabled) return incomingConfig
+
+    const collections = [...(incomingConfig.collections || [])]
+
+    const usersIdx = collections.findIndex((c) => (c as CollectionConfig).slug === 'users')
+    if (usersIdx >= 0) {
+      const users = collections[usersIdx] as CollectionConfig
+      const fields = [...(users.fields || [])]
+      if (!fields.some((f) => typeof f === 'object' && 'name' in f && f.name === 'tenant')) {
+        const localeIdx = fields.findIndex((f) => typeof f === 'object' && 'name' in f && f.name === 'locale')
+        const insertIdx = localeIdx >= 0 ? localeIdx + 1 : fields.length
+        fields.splice(insertIdx, 0, tenantField)
+        collections[usersIdx] = { ...users, fields }
+      }
+    }
+
+    const mediaIdx = collections.findIndex((c) => (c as CollectionConfig).slug === 'media')
+    if (mediaIdx >= 0) {
+      const media = collections[mediaIdx] as CollectionConfig
+      const mediaFields = [...(media.fields || [])]
+      if (!mediaFields.some((f) => typeof f === 'object' && 'name' in f && f.name === 'tenant')) {
+        mediaFields.unshift({
+          name: 'tenant',
+          type: 'relationship' as const,
+          relationTo: 'tenants',
+          admin: {
+            description: 'Vendor tenant. Null = platform media (admin-uploaded).',
+          },
+        })
+        collections[mediaIdx] = {
+          ...media,
+          fields: mediaFields,
+          access: {
+            create: ({ req }) => Boolean(req.user),
+            read: ({ req }) => {
+              if (!req.user) return true
+              if (req.user.role === 'admin') return true
+              if (req.user.role === 'vendor') return isAdminOrVendorOwner({ req })
+              return true
+            },
+            update: ({ req }) => {
+              if (!req.user) return false
+              if (req.user.role === 'admin') return true
+              if (req.user.role === 'vendor') return isAdminOrVendorOwner({ req })
+              return false
+            },
+            delete: ({ req }) => {
+              if (!req.user) return false
+              if (req.user.role === 'admin') return true
+              if (req.user.role === 'vendor') return isAdminOrVendorOwner({ req })
+              return false
+            },
+          },
+          hooks: {
+            ...(media.hooks || {}),
+            beforeValidate: [
+              ...(Array.isArray(media.hooks?.beforeValidate) ? media.hooks.beforeValidate : []),
+              ({ data, req }) => {
+                if (!data || req.user?.role !== 'vendor') return data
+                if (req.user?.tenant && !data.tenant) {
+                  const t = req.user.tenant
+                  data.tenant = typeof t === 'object' && t && 'id' in t ? (t as { id: string }).id : t
+                }
+                return data
+              },
+            ],
+          },
+        }
+      }
+    }
+
+    return {
+      ...incomingConfig,
+      collections: [
+        ...collections,
+        Tenants,
+        VendorProfiles,
+        VendorSettings,
+        VendorApplications,
+      ],
+    }
+  }

--- a/packages/backend/tsconfig.migrate.json
+++ b/packages/backend/tsconfig.migrate.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".next", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -1,0 +1,18 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./types"), exports);
+__exportStar(require("./utils"), exports);

--- a/packages/shared/src/types/index.js
+++ b/packages/shared/src/types/index.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/packages/shared/src/utils/index.js
+++ b/packages/shared/src/utils/index.js
@@ -1,0 +1,25 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.formatPrice = formatPrice;
+exports.generateOrderNumber = generateOrderNumber;
+exports.slugify = slugify;
+function formatPrice(amount, currency, locale = 'en') {
+    return new Intl.NumberFormat(locale === 'bn' ? 'bn-BD' : 'en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+    }).format(amount);
+}
+function generateOrderNumber(date = new Date()) {
+    const datePart = date.toISOString().slice(0, 10).replace(/-/g, '');
+    const randomPart = Math.random().toString(36).toUpperCase().slice(2, 6);
+    return `ORD-${datePart}-${randomPart}`;
+}
+function slugify(text) {
+    return text
+        .toLowerCase()
+        .trim()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/[\s_-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Phase 4 — Multivendor Foundation

### Summary
Implements the multivendor foundation plugin with tenant setup, vendor profiles, vendor application flow, and tenant-scoped access control.

### What's included

**Collections (when `MULTIVENDOR_ENABLED=true`)**
- **Tenants** — Vendors; admin CRUD; vendors read own tenant only
- **VendorProfiles** — Public store profiles at `/store/[vendor-slug]`
- **VendorSettings** — Per-tenant settings (commission, payout, shipping overrides)
- **VendorApplications** — Vendor onboarding; approval creates tenant, profile, settings, and updates user role

**Access control**
- Vendors see and manage only their own tenant's products, media, profiles, settings
- Admin has full access
- Customers/guests read public data (e.g. vendor profiles, published products)

**Vendor application flow**
- Customer submits application (applicant auto-set from logged-in user)
- Admin approves → creates Tenant, VendorProfile, VendorSettings; sets User role to vendor and links tenant
- `VENDOR_AUTO_APPROVE=true` auto-approves on create

**MULTIVENDOR_ENABLED toggle**
- `false`: No multivendor collections; no tenant fields on products/media/users
- `true`: Full multivendor mode

### Other changes
- Users collection moved to `collections/users/index.ts` (fixes `ERR_UNSUPPORTED_DIR_IMPORT` for `payload migrate`)
- Media read access fixed for vendor tenant-scoping (vendors only see own media)
- OpenAPI updated to v0.4.0 with Phase 4 endpoints

### Testing
See `docs/PHASE-4-TEST-PROCEDURE.md` for test steps.