### PR TITLE
feat(phase-5): Multivendor Commerce

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -87,20 +87,26 @@ FACEBOOK_APP_ID=your-facebook-app-id
 FACEBOOK_APP_SECRET=your-facebook-app-secret
 
 # ═══════════════════════════════════════════════════
-# COMMISSIONS
+# COMMISSIONS (Phase 5)
 # Only active when MULTIVENDOR_ENABLED=true
+# 0 = no commission by default; set in admin or VendorSettings per business need
 # ═══════════════════════════════════════════════════
 COMMISSION_STRATEGY=percentage
-DEFAULT_COMMISSION_RATE=10
+DEFAULT_COMMISSION_RATE=0
 
 # ═══════════════════════════════════════════════════
-# PAYOUTS
+# PAYOUTS (Phase 5)
 # Decision #14: Manual ledger by default (SSLCommerz doesn't support split payments)
 # Only active when MULTIVENDOR_ENABLED=true
 # ═══════════════════════════════════════════════════
 PAYOUT_SCHEDULE=biweekly
 PAYOUT_HOLD_DAYS=7
 PAYOUT_ADAPTER=manual-ledger
+
+# When some sub-orders are delivered and others cancelled: fulfillment-only (default) = parent reflects
+# fulfilled segments only (e.g. delivered); strict = parent stays at most partially-shipped.
+# PARENT_ORDER_STATUS_STRATEGY=fulfillment-only
+# PARENT_ORDER_STATUS_STRATEGY=strict
 
 # ═══════════════════════════════════════════════════
 # SHIPPING

--- a/packages/backend/src/access/is-order-owner-or-admin.ts
+++ b/packages/backend/src/access/is-order-owner-or-admin.ts
@@ -2,20 +2,31 @@ import type { Access } from 'payload'
 
 /**
  * Allows access if admin, or if the order belongs to the current user (customer field),
- * or if guest and they provide order ID + guestEmail match.
+ * or if vendor and the order has a sub-order for their tenant.
  * Used for Orders collection.
  */
-export const isOrderOwnerOrAdmin: Access = ({ req, id }) => {
+export const isOrderOwnerOrAdmin: Access = async ({ req }) => {
   const user = req.user
-  if (!user && !id) return false
-  if (user?.role === 'admin') return true
-  if (user) {
-    return {
-      customer: {
-        equals: user.id,
-      },
+  if (!user) return false
+  if (user.role === 'admin') return true
+  if (user.role === 'customer') {
+    return { customer: { equals: user.id } } as any
+  }
+  if (user.role === 'vendor' && user.tenant) {
+    try {
+      const tenantId = typeof user.tenant === 'object' ? user.tenant.id : user.tenant
+      const { docs } = await req.payload.find({
+        collection: 'sub-orders',
+        where: { tenant: { equals: tenantId } },
+        limit: 5000,
+        depth: 0,
+      })
+      const orderIds = [...new Set(docs.map((d) => (typeof d.parentOrder === 'object' ? d.parentOrder?.id : d.parentOrder)).filter(Boolean) as string[])]
+      if (orderIds.length === 0) return false
+      return { id: { in: orderIds } } as any
+    } catch {
+      return false
     }
   }
-  // Guest: can only read by ID + email verification (handled at API level)
   return false
 }

--- a/packages/backend/src/app/(app)/layout.tsx
+++ b/packages/backend/src/app/(app)/layout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   )
 }

--- a/packages/backend/src/globals/platform-settings.ts
+++ b/packages/backend/src/globals/platform-settings.ts
@@ -127,11 +127,11 @@ export const PlatformSettings: GlobalConfig = {
         {
           name: 'defaultCommissionRate',
           type: 'number',
-          defaultValue: 10,
+          defaultValue: 0,
           min: 0,
           max: 100,
           admin: {
-            description: 'Default commission % applied to all vendors unless overridden.',
+            description: 'Default commission % applied to all vendors unless overridden. 0 = no commission (business sets their rate).',
             step: 0.01,
           },
         },

--- a/packages/backend/src/lib/commission.ts
+++ b/packages/backend/src/lib/commission.ts
@@ -1,0 +1,41 @@
+/**
+ * Commission calculation — Phase 5.
+ * Simple percentage strategy (default). Full CommissionStrategy pattern in commissions plugin.
+ * Default rate is 0 — commission is a business decision; set in admin or VendorSettings.
+ */
+import type { Payload } from 'payload'
+
+/**
+ * Get commission rate for a tenant. Checks VendorSettings override, falls back to env/platform default (0 if unset).
+ */
+export async function getCommissionRateForTenant(
+  payload: Payload,
+  tenantId: string
+): Promise<number> {
+  const defaultRate = Number(process.env.DEFAULT_COMMISSION_RATE ?? '0')
+  if (tenantId === '__platform__') return 0
+
+  try {
+    const { docs } = await payload.find({
+      collection: 'vendor-settings',
+      where: { tenant: { equals: tenantId } },
+      limit: 1,
+      depth: 0,
+    })
+    const settings = docs[0]
+    if (settings?.commissionRate != null && !isNaN(settings.commissionRate)) {
+      return Math.min(100, Math.max(0, settings.commissionRate))
+    }
+  } catch (_) {
+    // vendor-settings may not exist or tenant may be invalid
+  }
+  return defaultRate
+}
+
+/**
+ * Calculate commission amount for a subtotal using percentage.
+ */
+export function calculateCommission(subtotal: number, ratePercent: number): { amount: number; rate: number } {
+  const amount = Math.round((subtotal * (ratePercent / 100)) * 100) / 100
+  return { amount, rate: ratePercent }
+}

--- a/packages/backend/src/lib/consume-order-inventory.ts
+++ b/packages/backend/src/lib/consume-order-inventory.ts
@@ -1,0 +1,66 @@
+/**
+ * Consume inventory when an order (or sub-order) is shipped/fulfilled.
+ * Decrements both quantity and reservedQuantity on matching stock-levels.
+ *
+ * Call once when status transitions to `shipped` (reservation is consumed, physical stock reduced).
+ * Used by: SubOrders afterChange (status -> shipped).
+ */
+import type { Payload, PayloadRequest } from 'payload'
+import type { OrderItemLike } from './release-order-inventory'
+
+export async function consumeOrderInventory(
+  payload: Payload,
+  items: OrderItemLike[],
+  req?: PayloadRequest
+): Promise<void> {
+  if (!items?.length) return
+
+  const productIds = [...new Set(items.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[])]
+  if (!productIds.length) return
+
+  const stockLevels = await payload.find({
+    collection: 'stock-levels',
+    where: { product: { in: productIds } },
+    limit: 100,
+    depth: 1,
+  })
+
+  for (const item of items) {
+    if (!item.product) continue
+    const productId = typeof item.product === 'object' ? item.product?.id : item.product
+    const variantId = item.variant
+      ? typeof item.variant === 'object'
+        ? (item.variant as { id: string })?.id
+        : item.variant
+      : null
+    const quantity = Number(item.quantity) || 1
+
+    const level = (
+      stockLevels.docs as Array<{
+        id: string
+        product?: string | { id: string }
+        variant?: string | { id: string } | null
+        quantity?: number
+        reservedQuantity?: number
+      }>
+    ).find((sl) => {
+      const slProduct = typeof sl.product === 'object' ? sl.product?.id : sl.product
+      const slVariant = typeof sl.variant === 'object' ? sl.variant?.id : sl.variant
+      return slProduct === productId && (variantId ? slVariant === variantId : !slVariant)
+    })
+
+    if (level) {
+      const currentQty = Number(level.quantity) || 0
+      const reserved = Number(level.reservedQuantity) || 0
+      const newQuantity = Math.max(0, currentQty - quantity)
+      const newReserved = Math.max(0, reserved - quantity)
+      await payload.update({
+        collection: 'stock-levels',
+        id: level.id,
+        overrideAccess: true,
+        data: { quantity: newQuantity, reservedQuantity: newReserved },
+        ...(req && { req }),
+      })
+    }
+  }
+}

--- a/packages/backend/src/lib/order-status-transitions.ts
+++ b/packages/backend/src/lib/order-status-transitions.ts
@@ -1,0 +1,86 @@
+/**
+ * Allowed order / sub-order status transitions.
+ * Prevents invalid flows (e.g. cancel after shipped) and keeps inventory logic consistent.
+ *
+ * Rules:
+ * - Cancel only from pending/confirmed/processing (before ship); once shipped, use returns/refunds.
+ * - Terminal states: cancelled, refunded, completed — no further transitions.
+ * - Forward flow: pending → … → shipped → delivered → completed.
+ */
+import { APIError } from 'payload'
+
+/** Allowed next statuses for sub-order (per-vendor segment). */
+const SUB_ORDER_TRANSITIONS: Record<string, string[]> = {
+  pending: ['confirmed', 'processing', 'cancelled'],
+  confirmed: ['processing', 'cancelled'],
+  processing: ['shipped', 'cancelled'],
+  shipped: ['delivered'],
+  delivered: ['completed'],
+  completed: [],
+  cancelled: [],
+  refunded: [],
+}
+
+/** Allowed next statuses for main order (includes partially-shipped for multivendor). Cancel only before any ship. */
+const ORDER_TRANSITIONS: Record<string, string[]> = {
+  pending: ['processing', 'cancelled'],
+  processing: ['partially-shipped', 'shipped', 'cancelled'],
+  'partially-shipped': ['shipped'], // no cancel once any sub-order has shipped
+  shipped: ['delivered'],
+  delivered: ['completed'],
+  completed: [],
+  cancelled: [],
+  refunded: [],
+}
+
+function getAllowedNext(current: string, transitions: Record<string, string[]>): string[] {
+  return transitions[current] ?? []
+}
+
+/**
+ * Returns true if the transition is allowed for a sub-order.
+ */
+export function isAllowedSubOrderStatusTransition(from: string, to: string): boolean {
+  if (!from || !to || from === to) return true
+  return getAllowedNext(from, SUB_ORDER_TRANSITIONS).includes(to)
+}
+
+/**
+ * Returns true if the transition is allowed for a main order.
+ */
+export function isAllowedOrderStatusTransition(from: string, to: string): boolean {
+  if (!from || !to || from === to) return true
+  return getAllowedNext(from, ORDER_TRANSITIONS).includes(to)
+}
+
+/**
+ * Throws a Payload error if the sub-order transition is invalid (for use in beforeChange).
+ */
+export function validateSubOrderStatusTransition(from: string | undefined, to: string | undefined): void {
+  if (to == null) return
+  const fromStatus = from ?? 'pending'
+  if (!isAllowedSubOrderStatusTransition(fromStatus, to)) {
+    const allowed = getAllowedNext(fromStatus, SUB_ORDER_TRANSITIONS)
+    const allowedText = allowed.length ? allowed.join(', ') : 'none (terminal)'
+    throw new APIError(
+      `Allowed next: ${allowedText}. Cannot change "${fromStatus}" → "${to}".`,
+      400
+    )
+  }
+}
+
+/**
+ * Throws a Payload error if the order transition is invalid (for use in beforeChange).
+ */
+export function validateOrderStatusTransition(from: string | undefined, to: string | undefined): void {
+  if (to == null) return
+  const fromStatus = from ?? 'pending'
+  if (!isAllowedOrderStatusTransition(fromStatus, to)) {
+    const allowed = getAllowedNext(fromStatus, ORDER_TRANSITIONS)
+    const allowedText = allowed.length ? allowed.join(', ') : 'none (terminal)'
+    throw new APIError(
+      `Allowed next: ${allowedText}. Cannot change "${fromStatus}" → "${to}".`,
+      400
+    )
+  }
+}

--- a/packages/backend/src/lib/process-checkout.ts
+++ b/packages/backend/src/lib/process-checkout.ts
@@ -1,14 +1,17 @@
 /**
  * Process checkout: create Order + Order Items + Transaction from Cart.
- * Phase 3 single-vendor: no sub-orders, no commission.
+ * Phase 3: single-vendor, no sub-orders.
+ * Phase 5: when MULTIVENDOR_ENABLED, splits by vendor into sub-orders, calculates commission.
  *
  * All DB writes run in a single transaction when the adapter supports it (Postgres).
- * MongoDB: beginTransaction may return null — operations run without a transaction (best-effort).
  * Email is sent after commit. Used by process-checkout API and (future) payment webhooks.
  */
 import type { Payload, PayloadRequest } from 'payload'
 import { NotFound } from 'payload'
 import { getDefaultCurrency } from './currencies'
+import { DefaultOrderSplitter, getPlatformItems } from '../plugins/orders/strategies/order-splitter'
+import type { CartItemForSplit } from '../plugins/orders/strategies/order-splitter'
+import { getCommissionRateForTenant, calculateCommission } from './commission'
 
 /** Creates req with transactionID when adapter supports transactions. */
 function reqWithTransaction(req: PayloadRequest | undefined, transactionID: string | number | null): PayloadRequest {
@@ -17,8 +20,9 @@ function reqWithTransaction(req: PayloadRequest | undefined, transactionID: stri
   return { ...base, transactionID }
 }
 
+const splitByVendor = process.env.MULTIVENDOR_ENABLED === 'true'
+
 export interface ProcessCheckoutInput {
-  /** Cart ID (UUID string or legacy number). Payload findByID accepts both. */
   cartId: string | number
   shippingAddress: {
     firstName: string
@@ -42,34 +46,26 @@ export interface ProcessCheckoutInput {
     country: string
     phone?: string
   }
-  /** Optional. Required for guest checkout. */
   guestEmail?: string
-  /** Optional. For testing without real payment. */
   simulatePayment?: boolean
-  /** Optional. Default from cart currency or platform default. */
   currency?: string
 }
 
 export interface ProcessCheckoutResult {
-  /** IDs are strings (UUID standard). See docs/ID-STANDARD.md */
   order: { id: string; orderNumber: string }
   transaction?: { id: string }
   error?: string
-  /** HTTP status when error is set (e.g. 404 for cart not found) */
   statusCode?: number
 }
 
 export async function processCheckout(
   payload: Payload,
   input: ProcessCheckoutInput,
-  /** User ID. String with UUID; number with serial. Pass raw from req.user.id. */
   userId?: string | number,
-  /** Request context for hooks (e.g. orders afterChange). Omit for webhooks. */
   req?: PayloadRequest
 ): Promise<ProcessCheckoutResult> {
   const { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment = false } = input
 
-  // 1. Load cart with items (findByID throws NotFound if missing)
   let cart: Awaited<ReturnType<Payload['findByID']>>
   try {
     cart = await payload.findByID({
@@ -101,19 +97,8 @@ export async function processCheckout(
 
   const currency = input.currency || getDefaultCurrency()
 
-  // 2. Compute order item data and subtotal
-  const orderItemData: Array<{
-    productId: string
-    variantId: string | null
-    productName: string
-    variantName: string
-    sku: string
-    quantity: number
-    unitPrice: number
-    totalPrice: number
-    productImage: string
-  }> = []
-  let subtotal = 0
+  // Build order item data with tenantId (for multivendor)
+  const orderItemData: CartItemForSplit[] = []
 
   for (const item of items) {
     const productId = typeof item.product === 'object' ? item.product?.id : item.product
@@ -122,15 +107,22 @@ export async function processCheckout(
     const product = await payload.findByID({
       collection: 'products',
       id: productId as string,
-      depth: 0,
+      depth: 1,
     })
 
     if (!product) {
       return { order: { id: '', orderNumber: '' }, error: `Product ${productId} not found` }
     }
 
+    const productAny = product as { tenant?: { id: string } | string | null; name?: string; sku?: string; basePrice?: number }
+    const tenantId = productAny.tenant
+      ? typeof productAny.tenant === 'object'
+        ? productAny.tenant?.id ?? null
+        : productAny.tenant
+      : null
+
     let variantName = ''
-    let sku = (product as { sku?: string }).sku || ''
+    let sku = productAny.sku || ''
     let unitPrice = item.unitPrice
 
     if (variantId) {
@@ -140,36 +132,37 @@ export async function processCheckout(
         depth: 0,
       })
       if (variant) {
-        variantName = (variant as { name?: string }).name || ''
-        sku = (variant as { sku?: string }).sku || sku
-        unitPrice = (variant as { price?: number }).price ?? unitPrice
+        const v = variant as { name?: string; sku?: string; price?: number }
+        variantName = v.name || ''
+        sku = v.sku || sku
+        unitPrice = v.price ?? unitPrice
       }
     } else {
-      unitPrice = (product as { basePrice?: number }).basePrice ?? unitPrice
+      unitPrice = productAny.basePrice ?? unitPrice
     }
 
     const quantity = Number(item.quantity) || 1
     const totalPrice = Math.round(quantity * unitPrice * 100) / 100
-    subtotal += totalPrice
 
     orderItemData.push({
       productId: productId as string,
       variantId: variantId as string | null,
-      productName: (product as { name?: string }).name || 'Product',
+      productName: productAny.name || 'Product',
       variantName,
       sku,
       quantity,
       unitPrice,
       totalPrice,
       productImage: '',
+      tenantId,
     })
   }
 
-  // 3. Calculate totals (Phase 3: simple - no shipping calc, no tax)
   const shippingTotal = 0
   const taxTotal = 0
   const discountTotal = 0
-  const grandTotal = Math.round((subtotal + shippingTotal + taxTotal - discountTotal) * 100) / 100
+  const subtotalCalc = orderItemData.reduce((s, i) => s + i.totalPrice, 0)
+  const grandTotal = Math.round((subtotalCalc + shippingTotal + taxTotal - discountTotal) * 100) / 100
 
   const orderNumber = `ORD-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}-${Math.random().toString(36).substring(2, 6).toUpperCase()}`
 
@@ -180,28 +173,26 @@ export async function processCheckout(
   let paymentTransactionId: string | undefined
 
   try {
+    const subtotal = orderItemData.reduce((s, i) => s + i.totalPrice, 0)
     const orderData: Record<string, unknown> = {
-    orderNumber,
-    status: 'pending',
-    items: [],
-    shippingAddress,
-    billingAddress,
-    subtotal,
-    shippingTotal,
-    taxTotal,
-    discountTotal,
-    grandTotal,
-    currency,
-    paymentStatus: 'unpaid', // Set to paid in single update when simulatePayment (avoids inconsistent state)
-    notes: '',
-    placedAt: new Date().toISOString(),
-  }
-  if (userId) {
-    orderData.customer = userId
-  }
-    if (guestEmail) {
-      orderData.guestEmail = guestEmail
+      orderNumber,
+      status: 'pending',
+      items: [],
+      shippingAddress,
+      billingAddress,
+      subtotal,
+      shippingTotal,
+      taxTotal,
+      discountTotal,
+      grandTotal,
+      currency,
+      paymentStatus: 'unpaid',
+      notes: '',
+      placedAt: new Date().toISOString(),
     }
+    if (userId) orderData.customer = userId
+    if (guestEmail) orderData.guestEmail = guestEmail
+    if (splitByVendor) orderData.subOrders = []
 
     order = await payload.create({
       collection: 'orders',
@@ -227,32 +218,131 @@ export async function processCheckout(
     })
 
     const orderItemIds: string[] = []
-    for (const d of orderItemData) {
-      const itemData: Record<string, unknown> = {
-        order: orderId,
-        product: d.productId,
-        productName: d.productName,
-        variantName: d.variantName,
-        sku: d.sku,
-        quantity: d.quantity,
-        unitPrice: d.unitPrice,
-        totalPrice: d.totalPrice,
-        productImage: d.productImage,
-      }
-      if (d.variantId != null) {
-        itemData.variant = d.variantId
+    const subOrderIds: string[] = []
+
+    if (splitByVendor) {
+      const platformItems = getPlatformItems(orderItemData)
+      const splitter = new DefaultOrderSplitter()
+      const segments = splitter.split(orderItemData)
+
+      // Create sub-orders for vendor segments
+      for (let i = 0; i < segments.length; i++) {
+        const seg = segments[i]
+        const { amount: commissionAmount, rate: commissionRate } = await (async () => {
+          const rate = await getCommissionRateForTenant(payload, seg.tenantId)
+          return calculateCommission(seg.subtotal, rate)
+        })()
+        const vendorEarnings = Math.round((seg.subtotal - commissionAmount) * 100) / 100
+
+        const subOrderNumber = `${orderNumber}-${String.fromCharCode(65 + i)}`
+        const subOrder = await payload.create({
+          collection: 'sub-orders',
+          overrideAccess: true,
+          data: {
+            parentOrder: orderId,
+            parentOrderNumber: orderNumber,
+            tenant: seg.tenantId,
+            subOrderNumber,
+            status: 'pending',
+            items: [],
+            subtotal: seg.subtotal,
+            shippingTotal: 0,
+            taxTotal: 0,
+            commissionAmount,
+            commissionRate,
+            vendorEarnings,
+          } as any,
+          req: reqTx,
+        })
+        subOrderIds.push(subOrder.id as string)
+
+        for (const d of seg.items) {
+          const itemData: Record<string, unknown> = {
+            order: orderId,
+            subOrder: subOrder.id,
+            tenant: seg.tenantId,
+            product: d.productId,
+            productName: d.productName,
+            variantName: d.variantName,
+            sku: d.sku,
+            quantity: d.quantity,
+            unitPrice: d.unitPrice,
+            totalPrice: d.totalPrice,
+            productImage: d.productImage,
+          }
+          if (d.variantId != null) itemData.variant = d.variantId
+
+          const orderItem = await payload.create({
+            collection: 'order-items',
+            overrideAccess: true,
+            data: itemData as any,
+            req: reqTx,
+          })
+          orderItemIds.push(orderItem.id as string)
+        }
+
+        // Update sub-order with item IDs
+        const segItemIds = orderItemIds.slice(-seg.items.length)
+        await payload.update({
+          collection: 'sub-orders',
+          id: subOrder.id,
+          overrideAccess: true,
+          data: { items: segItemIds } as any,
+          req: reqTx,
+        })
       }
 
-      const orderItem = await payload.create({
-        collection: 'order-items',
-        overrideAccess: true,
-        data: itemData as any,
-        req: reqTx,
-      })
-      orderItemIds.push(orderItem.id as string)
+      // Platform items (no sub-order)
+      for (const d of platformItems) {
+        const itemData: Record<string, unknown> = {
+          order: orderId,
+          product: d.productId,
+          productName: d.productName,
+          variantName: d.variantName,
+          sku: d.sku,
+          quantity: d.quantity,
+          unitPrice: d.unitPrice,
+          totalPrice: d.totalPrice,
+          productImage: d.productImage,
+        }
+        if (d.variantId != null) itemData.variant = d.variantId
+
+        const orderItem = await payload.create({
+          collection: 'order-items',
+          overrideAccess: true,
+          data: itemData as any,
+          req: reqTx,
+        })
+        orderItemIds.push(orderItem.id as string)
+      }
+    } else {
+      // Single-vendor: no sub-orders
+      for (const d of orderItemData) {
+        const itemData: Record<string, unknown> = {
+          order: orderId,
+          product: d.productId,
+          productName: d.productName,
+          variantName: d.variantName,
+          sku: d.sku,
+          quantity: d.quantity,
+          unitPrice: d.unitPrice,
+          totalPrice: d.totalPrice,
+          productImage: d.productImage,
+        }
+        if (d.variantId != null) itemData.variant = d.variantId
+
+        const orderItem = await payload.create({
+          collection: 'order-items',
+          overrideAccess: true,
+          data: itemData as any,
+          req: reqTx,
+        })
+        orderItemIds.push(orderItem.id as string)
+      }
     }
 
     const orderUpdateData: Record<string, unknown> = { items: orderItemIds }
+    if (splitByVendor && subOrderIds.length) orderUpdateData.subOrders = subOrderIds
 
     const updateReq = { ...reqTx, context: { ...(reqTx.context || {}), skipOrderStatusHistory: simulatePayment } }
     if (simulatePayment) {
@@ -277,7 +367,7 @@ export async function processCheckout(
       orderUpdateData.status = 'processing'
     }
 
-    const updatedOrder = await payload.update({
+    await payload.update({
       collection: 'orders',
       id: order.id,
       overrideAccess: true,
@@ -285,7 +375,7 @@ export async function processCheckout(
       req: updateReq,
     })
 
-    if (simulatePayment && updatedOrder) {
+    if (simulatePayment) {
       const statusHistoryData: Record<string, unknown> = {
         order: orderId,
         fromStatus: 'pending',
@@ -301,6 +391,7 @@ export async function processCheckout(
       })
     }
 
+    // Reserve inventory
     const productIds = [...new Set(items.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[])]
     const stockLevels = await payload.find({
       collection: 'stock-levels',
@@ -347,7 +438,6 @@ export async function processCheckout(
     throw err
   }
 
-  // Send order confirmation email (after commit; failure does not affect order)
   let recipientEmail: string | undefined
   if (guestEmail) recipientEmail = guestEmail
   else if (userId) {
@@ -356,7 +446,8 @@ export async function processCheckout(
   }
   if (recipientEmail) {
     const { sendOrderConfirmationEmail } = await import('../plugins/notifications/lib/send-email')
-    sendOrderConfirmationEmail(orderNumber, recipientEmail, grandTotal, currency).catch((e) =>
+    const gTotal = orderItemData.reduce((s, i) => s + i.totalPrice, 0)
+    sendOrderConfirmationEmail(orderNumber, recipientEmail, gTotal, currency).catch((e) =>
       console.error('[processCheckout] Failed to send order email:', e)
     )
   }

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -20,6 +20,8 @@ import { inventoryPlugin } from './plugins/inventory'
 import { shippingPlugin } from './plugins/shipping'
 import { paymentsPlugin } from './plugins/payments'
 import { ordersPlugin } from './plugins/orders'
+import { commissionsPlugin } from './plugins/commissions'
+import { payoutsPlugin } from './plugins/payouts'
 import { notificationsPlugin } from './plugins/notifications'
 
 import { Header } from './globals/header'
@@ -211,6 +213,17 @@ export default buildConfig({
       enabled: true,
       splitByVendor: process.env.MULTIVENDOR_ENABLED === 'true',
       orderStateMachine: 'default',
+    }),
+    commissionsPlugin({
+      enabled: process.env.MULTIVENDOR_ENABLED === 'true',
+      defaultStrategy: (process.env.COMMISSION_STRATEGY as 'percentage' | 'flat' | 'tiered' | 'category-based') || 'percentage',
+      defaultRate: Number(process.env.DEFAULT_COMMISSION_RATE ?? '0'),
+    }),
+    payoutsPlugin({
+      enabled: process.env.MULTIVENDOR_ENABLED === 'true',
+      schedule: process.env.PAYOUT_SCHEDULE || 'biweekly',
+      holdDays: Number(process.env.PAYOUT_HOLD_DAYS || '7'),
+      adapter: (process.env.PAYOUT_ADAPTER as 'manual-ledger' | 'stripe-transfer') || 'manual-ledger',
     }),
     notificationsPlugin({
       enabled: true,

--- a/packages/backend/src/plugins/commissions/collections/commission-rules.ts
+++ b/packages/backend/src/plugins/commissions/collections/commission-rules.ts
@@ -1,0 +1,83 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+/**
+ * Commission Rules — platform fee configuration.
+ * Supports percentage, flat, tiered, category-based strategies.
+ */
+export const CommissionRules: CollectionConfig = {
+  slug: 'commission-rules',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'type', 'rate', 'priority', 'isActive'],
+    group: 'Commissions',
+    description: 'Platform commission rules. Higher priority wins when multiple rules apply.',
+  },
+  access: {
+    create: isAdmin,
+    read: ({ req }) => Boolean(req.user),
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    { name: 'name', type: 'text', required: true, admin: { description: 'Human-readable rule name.' } },
+    {
+      name: 'type',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Percentage', value: 'percentage' },
+        { label: 'Flat', value: 'flat' },
+        { label: 'Tiered', value: 'tiered' },
+        { label: 'Category-based', value: 'category-based' },
+      ],
+    },
+    {
+      name: 'rate',
+      type: 'number',
+      min: 0,
+      admin: { description: 'For percentage: rate %. For flat: fixed amount.' },
+    },
+    {
+      name: 'tiers',
+      type: 'array',
+      admin: { description: 'For tiered: minAmount, maxAmount, rate.' },
+      fields: [
+        { name: 'minAmount', type: 'number', required: true },
+        { name: 'maxAmount', type: 'number' },
+        { name: 'rate', type: 'number', required: true },
+      ],
+    },
+    {
+      name: 'categories',
+      type: 'relationship',
+      relationTo: 'categories',
+      hasMany: true,
+      admin: { description: 'For category-based: applies to these categories.' },
+    },
+    {
+      name: 'categoryRate',
+      type: 'number',
+      min: 0,
+      admin: { description: 'Rate for category-based rule.' },
+    },
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      admin: { description: 'Null = global default. Set for vendor override.' },
+    },
+    {
+      name: 'priority',
+      type: 'number',
+      defaultValue: 0,
+      admin: { description: 'Higher priority wins. Default 0.' },
+    },
+    {
+      name: 'isActive',
+      type: 'checkbox',
+      defaultValue: true,
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/commissions/index.ts
+++ b/packages/backend/src/plugins/commissions/index.ts
@@ -1,0 +1,24 @@
+import type { Plugin } from 'payload'
+import { CommissionRules } from './collections/commission-rules'
+
+export interface CommissionsPluginOptions {
+  enabled?: boolean
+  defaultStrategy?: 'percentage' | 'flat' | 'tiered' | 'category-based'
+  defaultRate?: number
+}
+
+/**
+ * Commissions plugin — platform fee engine.
+ * Registers CommissionRules collection. Calculation used by process-checkout via lib/commission.
+ */
+export const commissionsPlugin =
+  (options: CommissionsPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = false } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [...(incomingConfig.collections || []), CommissionRules],
+    }
+  }

--- a/packages/backend/src/plugins/commissions/strategies/index.ts
+++ b/packages/backend/src/plugins/commissions/strategies/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Commission calculation strategies.
+ * See docs/MULTIVENDOR-ARCHITECTURE.md §8 Strategy Patterns.
+ */
+
+export interface CommissionContext {
+  subtotal: number
+  tenantId: string
+  categoryIds?: string[]
+}
+
+export interface CommissionResult {
+  amount: number
+  rate: number
+}
+
+export interface CommissionStrategy {
+  calculate(ctx: CommissionContext): Promise<CommissionResult> | CommissionResult
+}
+
+/** Percentage of subtotal. */
+export class PercentageCommissionStrategy implements CommissionStrategy {
+  constructor(private ratePercent: number) {}
+
+  calculate(ctx: CommissionContext): CommissionResult {
+    const amount = Math.round(ctx.subtotal * (this.ratePercent / 100) * 100) / 100
+    return { amount, rate: this.ratePercent }
+  }
+}
+
+/** Flat fee per order. */
+export class FlatFeeCommissionStrategy implements CommissionStrategy {
+  constructor(private flatAmount: number) {}
+
+  calculate(ctx: CommissionContext): CommissionResult {
+    return { amount: Math.round(this.flatAmount * 100) / 100, rate: 0 }
+  }
+}

--- a/packages/backend/src/plugins/ecommerce/collections/carts.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/carts.ts
@@ -1,6 +1,44 @@
 import type { CollectionConfig } from 'payload'
 
-export const Carts: CollectionConfig = {
+const itemFieldsBase = [
+  {
+    name: 'product',
+    type: 'relationship' as const,
+    relationTo: 'products',
+    required: true,
+  },
+  {
+    name: 'variant',
+    type: 'relationship' as const,
+    relationTo: 'product-variants',
+  },
+  { name: 'quantity', type: 'number' as const, required: true, min: 1 },
+  {
+    name: 'unitPrice',
+    type: 'number' as const,
+    required: false,
+    min: 0,
+    admin: { description: 'Auto-set from product basePrice or variant price. Do not send.' },
+  },
+]
+
+export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig {
+  const itemFields = [
+    ...itemFieldsBase.slice(0, 2),
+    ...(multivendorEnabled
+      ? [
+          {
+            name: 'vendor',
+            type: 'relationship' as const,
+            relationTo: 'tenants' as const,
+            admin: { description: 'Denormalized vendor for cart grouping. Auto-set from product.' },
+          },
+        ]
+      : []),
+    ...itemFieldsBase.slice(2),
+  ]
+
+  return {
   slug: 'carts',
   admin: {
     useAsTitle: 'id',
@@ -24,7 +62,7 @@ export const Carts: CollectionConfig = {
 
         if (!data.items || !Array.isArray(data.items)) return data
 
-        // Derive unitPrice from product/variant — never trust client (OWASP: price manipulation)
+        // Derive unitPrice and vendor from product/variant — never trust client (OWASP: price manipulation)
         for (const item of data.items) {
           const variantId = typeof item.variant === 'object' ? item.variant?.id : item.variant
           const productId = typeof item.product === 'object' ? item.product?.id : item.product
@@ -33,7 +71,7 @@ export const Carts: CollectionConfig = {
           const product = await req.payload.findByID({
             collection: 'products',
             id: productId,
-            depth: 0,
+            depth: 1,
           })
           if (!product) throw new Error(`Product ${productId} not found`)
 
@@ -55,6 +93,13 @@ export const Carts: CollectionConfig = {
             if (isNaN(unitPrice) || unitPrice < 0) throw new Error(`Invalid product basePrice for ${productId}`)
           }
           item.unitPrice = Math.round(unitPrice * 100) / 100
+          // Denormalize vendor (tenant) for multivendor cart grouping
+          if (process.env.MULTIVENDOR_ENABLED === 'true') {
+            const tenant = (product as { tenant?: { id: string } | string | null }).tenant
+            if (tenant != null) {
+              item.vendor = typeof tenant === 'object' ? tenant?.id : tenant
+            }
+          }
         }
 
         const subtotal = data.items.reduce(
@@ -103,27 +148,7 @@ export const Carts: CollectionConfig = {
       type: 'array',
       required: false, // Allow empty cart after checkout; required=true would reject []
       defaultValue: [],
-      fields: [
-        {
-          name: 'product',
-          type: 'relationship',
-          relationTo: 'products',
-          required: true,
-        },
-        {
-          name: 'variant',
-          type: 'relationship',
-          relationTo: 'product-variants',
-        },
-        { name: 'quantity', type: 'number', required: true, min: 1 },
-        {
-          name: 'unitPrice',
-          type: 'number',
-          required: false, // Server-populated from product/variant; client must not send
-          min: 0,
-          admin: { description: 'Auto-set from product basePrice or variant price. Do not send.' },
-        },
-      ],
+      fields: itemFields,
     },
     {
       name: 'subtotal',
@@ -138,4 +163,7 @@ export const Carts: CollectionConfig = {
     },
   ],
   timestamps: true,
+  }
 }
+
+export const Carts = createCartsConfig(false)

--- a/packages/backend/src/plugins/ecommerce/index.ts
+++ b/packages/backend/src/plugins/ecommerce/index.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'payload'
 import { createProductsConfig } from './collections/products'
 import { createProductVariantsConfig } from './collections/product-variants'
-import { Carts } from './collections/carts'
+import { createCartsConfig } from './collections/carts'
 import { Addresses } from './collections/addresses'
 
 export interface EcommercePluginOptions {
@@ -24,7 +24,7 @@ export const ecommercePlugin =
         ...(incomingConfig.collections || []),
         createProductsConfig(multivendorEnabled),
         createProductVariantsConfig(multivendorEnabled),
-        Carts,
+        createCartsConfig(multivendorEnabled),
         Addresses,
       ],
     }

--- a/packages/backend/src/plugins/orders/collections/order-items.ts
+++ b/packages/backend/src/plugins/orders/collections/order-items.ts
@@ -1,21 +1,9 @@
 import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
 
-export const OrderItems: CollectionConfig = {
-  slug: 'order-items',
-  admin: {
-    useAsTitle: 'productName',
-    defaultColumns: ['order', 'productName', 'variantName', 'quantity', 'unitPrice', 'totalPrice'],
-    group: 'Orders',
-    description: 'Line items for an order. Created at checkout from cart.',
-  },
-  access: {
-    create: isAdmin, // Only created via process-checkout, not by users directly
-    read: isAdmin, // Customers read via order
-    update: isAdmin,
-    delete: isAdmin,
-  },
-  fields: [
+export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig {
+  const fields: NonNullable<CollectionConfig['fields']> = [
     {
       name: 'order',
       type: 'relationship',
@@ -23,6 +11,22 @@ export const OrderItems: CollectionConfig = {
       required: true,
       admin: { description: 'Parent order.' },
     },
+    ...(splitByVendor
+      ? [
+          {
+            name: 'subOrder',
+            type: 'relationship' as const,
+            relationTo: 'sub-orders',
+            admin: { description: 'Vendor sub-order this item belongs to.' },
+          },
+          {
+            name: 'tenant',
+            type: 'relationship' as const,
+            relationTo: 'tenants',
+            admin: { description: 'Vendor who owns this item.' },
+          },
+        ]
+      : []),
     {
       name: 'product',
       type: 'relationship',
@@ -43,6 +47,15 @@ export const OrderItems: CollectionConfig = {
       admin: { description: 'Snapshot at time of purchase.' },
     },
     {
+      name: 'itemLabel',
+      type: 'text',
+      admin: {
+        description: 'Display label for admin (e.g. "Product Name × 2"). Set automatically.',
+        readOnly: true,
+        hidden: true, // used only for useAsTitle in relationship pills
+      },
+    },
+    {
       name: 'variantName',
       type: 'text',
       admin: { description: 'Snapshot at time of purchase.' },
@@ -60,6 +73,46 @@ export const OrderItems: CollectionConfig = {
       type: 'text',
       admin: { description: 'Snapshot URL at time of purchase.' },
     },
-  ],
-  timestamps: true,
+  ]
+
+  return {
+    slug: 'order-items',
+    admin: {
+      useAsTitle: 'itemLabel',
+      defaultColumns: splitByVendor
+        ? ['order', 'subOrder', 'productName', 'variantName', 'quantity', 'unitPrice', 'totalPrice']
+        : ['order', 'productName', 'variantName', 'quantity', 'unitPrice', 'totalPrice'],
+      group: 'Orders',
+      description: 'Line items for an order. Created at checkout from cart.',
+    },
+    access: {
+      create: isAdmin,
+      // Vendors need read so relationship titles (itemLabel) resolve in admin when viewing sub-orders
+      read: splitByVendor ? isAdminOrVendorOwner : isAdmin,
+      update: isAdmin,
+      delete: isAdmin,
+    },
+    fields,
+    timestamps: true,
+    hooks: {
+      beforeChange: [
+        ({ data }) => {
+          if (data?.productName != null) {
+            const qty = Number(data.quantity) ?? 1
+            data.itemLabel = `${data.productName} × ${qty}`
+          }
+          return data
+        },
+      ],
+      afterRead: [
+        ({ doc }) => {
+          if (doc && !doc.itemLabel && doc.productName) {
+            const qty = Number(doc.quantity) ?? 1
+            ;(doc as { itemLabel?: string }).itemLabel = `${doc.productName} × ${qty}`
+          }
+          return doc
+        },
+      ],
+    },
+  }
 }

--- a/packages/backend/src/plugins/orders/collections/orders.ts
+++ b/packages/backend/src/plugins/orders/collections/orders.ts
@@ -2,6 +2,8 @@ import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
 import { isOrderOwnerOrAdmin } from '../../../access/is-order-owner-or-admin'
 import { getDefaultCurrency } from '../../../lib/currencies'
+import { consumeOrderInventory } from '../../../lib/consume-order-inventory'
+import { validateOrderStatusTransition } from '../../../lib/order-status-transitions'
 import type { OrderItemLike } from '../../../lib/release-order-inventory'
 import { releaseOrderInventory } from '../../../lib/release-order-inventory'
 
@@ -17,113 +19,8 @@ const addressGroupFields = [
   { name: 'phone', type: 'text' as const },
 ]
 
-export const Orders: CollectionConfig = {
-  slug: 'orders',
-  admin: {
-    useAsTitle: 'orderNumber',
-    defaultColumns: ['orderNumber', 'customer', 'status', 'grandTotal', 'currency', 'placedAt'],
-    group: 'Orders',
-    description:
-      'Customer orders. Use status=Cancelled to cancel (releases inventory). Orders are never deleted (audit/tax).',
-  },
-  hooks: {
-    beforeDelete: [
-      async ({ id, req }) => {
-        const payload = req.payload
-        const orderId = id
-
-        const { docs: itemDocs } = await payload.find({
-          collection: 'order-items',
-          where: { order: { equals: orderId } },
-          limit: 1000,
-          depth: 1,
-        })
-        await releaseOrderInventory(payload, itemDocs as OrderItemLike[], req)
-
-        // Delete related records before order (FK constraints)
-        const { docs: historyDocs } = await payload.find({
-          collection: 'order-status-history',
-          where: { order: { equals: orderId } },
-          limit: 1000,
-          depth: 0,
-        })
-        for (const h of historyDocs) {
-          await payload.delete({ collection: 'order-status-history', id: h.id, overrideAccess: true, req })
-        }
-        const { docs: txDocs } = await payload.find({
-          collection: 'transactions',
-          where: { order: { equals: orderId } },
-          limit: 100,
-          depth: 0,
-        })
-        for (const tx of txDocs) {
-          await payload.delete({ collection: 'transactions', id: tx.id, overrideAccess: true, req })
-        }
-        for (const item of itemDocs) {
-          await payload.delete({ collection: 'order-items', id: item.id, overrideAccess: true, req })
-        }
-      },
-    ],
-    beforeChange: [
-      async ({ data, operation }) => {
-        if (operation === 'create' && data && !data.orderNumber) {
-          const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
-          const suffix = Math.random().toString(36).substring(2, 6).toUpperCase()
-          data.orderNumber = `ORD-${date}-${suffix}`
-        }
-        return data
-      },
-    ],
-    afterChange: [
-      async ({ doc, previousDoc, operation, req }) => {
-        // Skip create: order-status-history for new orders is created in process-checkout
-        if (operation === 'create') return doc
-
-        const payload = req.payload
-        const orderId = doc.id
-        const fromStatus = previousDoc?.status ?? null
-        const toStatus = doc.status
-
-        // Release reserved inventory when order is cancelled (industry standard: cancel, don't delete)
-        if (toStatus === 'cancelled') {
-          const { docs: itemDocs } = await payload.find({
-            collection: 'order-items',
-            where: { order: { equals: orderId } },
-            limit: 1000,
-            depth: 1,
-          })
-          await releaseOrderInventory(payload, itemDocs as OrderItemLike[], req)
-        }
-
-        // process-checkout creates status-history when simulatePayment; skip to avoid nested create
-        if ((req as { context?: { skipOrderStatusHistory?: boolean } })?.context?.skipOrderStatusHistory) return doc
-        if (fromStatus && toStatus && fromStatus !== toStatus) {
-          const historyData: Record<string, unknown> = {
-            order: orderId,
-            fromStatus,
-            toStatus,
-            timestamp: new Date().toISOString(),
-          }
-          if (req.user?.id != null) historyData.changedBy = req.user.id
-          await payload.create({
-            collection: 'order-status-history',
-            overrideAccess: true,
-            data: historyData as any,
-            req,
-          })
-        }
-        return doc
-      },
-    ],
-  },
-  access: {
-    create: isAdmin, // Orders created via process-checkout (overrideAccess)
-    read: isOrderOwnerOrAdmin,
-    update: isAdmin,
-    // Industry standard: never delete orders (audit, tax, disputes). Use status=cancelled instead.
-    delete: () => false,
-  },
-  fields: [
+export function createOrdersConfig(splitByVendor: boolean): CollectionConfig {
+  const baseFields: NonNullable<CollectionConfig['fields']> = [
     {
       name: 'orderNumber',
       type: 'text',
@@ -208,6 +105,154 @@ export const Orders: CollectionConfig = {
     },
     { name: 'notes', type: 'textarea', admin: { description: 'Customer notes.' } },
     { name: 'placedAt', type: 'date', admin: { description: 'When order was placed.' } },
-  ],
-  timestamps: true,
+  ]
+
+  if (splitByVendor) {
+    baseFields.splice(
+      baseFields.findIndex((f) => typeof f === 'object' && 'name' in f && f.name === 'items') + 1,
+      0,
+      {
+        name: 'subOrders',
+        type: 'relationship' as const,
+        relationTo: 'sub-orders',
+        hasMany: true,
+        admin: { description: 'Per-vendor segments. Vendors fulfill their sub-orders.' },
+      }
+    )
+  }
+
+  return {
+    slug: 'orders',
+    admin: {
+      useAsTitle: 'orderNumber',
+      defaultColumns: ['orderNumber', 'customer', 'status', 'grandTotal', 'currency', 'placedAt'],
+      group: 'Orders',
+      description:
+        'Customer orders. Use status=Cancelled to cancel (releases inventory). Orders are never deleted (audit/tax).',
+    },
+    hooks: {
+      beforeDelete: [
+        async ({ id, req }) => {
+          const payload = req.payload
+          const orderId = id
+
+          const { docs: itemDocs } = await payload.find({
+            collection: 'order-items',
+            where: { order: { equals: orderId } },
+            limit: 1000,
+            depth: 1,
+          })
+          await releaseOrderInventory(payload, itemDocs as OrderItemLike[], req)
+
+          // Delete related records before order (FK constraints)
+          const { docs: historyDocs } = await payload.find({
+            collection: 'order-status-history',
+            where: { order: { equals: orderId } },
+            limit: 1000,
+            depth: 0,
+          })
+          for (const h of historyDocs) {
+            await payload.delete({ collection: 'order-status-history', id: h.id, overrideAccess: true, req })
+          }
+          if (splitByVendor) {
+            const { docs: subOrderDocs } = await payload.find({
+              collection: 'sub-orders',
+              where: { parentOrder: { equals: orderId } },
+              limit: 100,
+              depth: 0,
+            })
+            for (const so of subOrderDocs) {
+              await payload.delete({ collection: 'sub-orders', id: so.id, overrideAccess: true, req })
+            }
+          }
+          const { docs: txDocs } = await payload.find({
+            collection: 'transactions',
+            where: { order: { equals: orderId } },
+            limit: 100,
+            depth: 0,
+          })
+          for (const tx of txDocs) {
+            await payload.delete({ collection: 'transactions', id: tx.id, overrideAccess: true, req })
+          }
+          for (const item of itemDocs) {
+            await payload.delete({ collection: 'order-items', id: item.id, overrideAccess: true, req })
+          }
+        },
+      ],
+      beforeChange: [
+        ({ data, operation, originalDoc }) => {
+          if (operation === 'update' && data?.status != null) {
+            const from = (originalDoc as { status?: string } | undefined)?.status
+            validateOrderStatusTransition(from, data.status as string)
+          }
+          if (operation === 'create' && data && !data.orderNumber) {
+            const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+            const suffix = Math.random().toString(36).substring(2, 6).toUpperCase()
+            data.orderNumber = `ORD-${date}-${suffix}`
+          }
+          return data
+        },
+      ],
+      afterChange: [
+        async ({ doc, previousDoc, operation, req }) => {
+          if (operation === 'create') return doc
+
+          const payload = req.payload
+          const orderId = doc.id
+          const fromStatus = previousDoc?.status ?? null
+          const toStatus = doc.status
+
+          if (toStatus === 'cancelled') {
+            const { docs: itemDocs } = await payload.find({
+              collection: 'order-items',
+              where: { order: { equals: orderId } },
+              limit: 1000,
+              depth: 1,
+            })
+            await releaseOrderInventory(payload, itemDocs as OrderItemLike[], req)
+          }
+
+          // Single-vendor: consume inventory when order status → shipped
+          const alreadyShipped = ['shipped', 'delivered', 'completed'].includes(fromStatus ?? '')
+          if (!splitByVendor && toStatus === 'shipped' && !alreadyShipped) {
+            const { docs: itemDocs } = await payload.find({
+              collection: 'order-items',
+              where: { order: { equals: orderId } },
+              limit: 1000,
+              depth: 1,
+            })
+            await consumeOrderInventory(payload, itemDocs as OrderItemLike[], req)
+          }
+
+          if ((req as { context?: { skipOrderStatusHistory?: boolean } })?.context?.skipOrderStatusHistory)
+            return doc
+          if (fromStatus && toStatus && fromStatus !== toStatus) {
+            const historyData: Record<string, unknown> = {
+              order: orderId,
+              fromStatus,
+              toStatus,
+              timestamp: new Date().toISOString(),
+            }
+            if (req.user?.id != null) historyData.changedBy = req.user.id
+            await payload.create({
+              collection: 'order-status-history',
+              overrideAccess: true,
+              data: historyData as any,
+              req,
+            })
+          }
+          return doc
+        },
+      ],
+    },
+    access: {
+      create: isAdmin,
+      read: isOrderOwnerOrAdmin,
+      update: isAdmin,
+      delete: () => false,
+    },
+    fields: baseFields,
+    timestamps: true,
+  }
 }
+

--- a/packages/backend/src/plugins/orders/collections/sub-orders.ts
+++ b/packages/backend/src/plugins/orders/collections/sub-orders.ts
@@ -1,0 +1,245 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
+import { consumeOrderInventory } from '../../../lib/consume-order-inventory'
+import { validateSubOrderStatusTransition } from '../../../lib/order-status-transitions'
+import type { OrderItemLike } from '../../../lib/release-order-inventory'
+import { releaseOrderInventory } from '../../../lib/release-order-inventory'
+
+const subOrderStatusOptions = [
+  { label: 'Pending', value: 'pending' },
+  { label: 'Confirmed', value: 'confirmed' },
+  { label: 'Processing', value: 'processing' },
+  { label: 'Shipped', value: 'shipped' },
+  { label: 'Delivered', value: 'delivered' },
+  { label: 'Completed', value: 'completed' },
+  { label: 'Cancelled', value: 'cancelled' },
+  { label: 'Refunded', value: 'refunded' },
+]
+
+/**
+ * Sub-Orders — per-vendor segments of a parent order.
+ * When MULTIVENDOR_ENABLED, each vendor's items become a sub-order.
+ * Vendors see only their sub-orders. Parent order status is derived from sub-order statuses.
+ */
+export const SubOrders: CollectionConfig = {
+  slug: 'sub-orders',
+  admin: {
+    useAsTitle: 'subOrderNumber',
+    defaultColumns: ['subOrderNumber', 'parentOrderNumber', 'tenant', 'status', 'subtotal', 'vendorEarnings', 'commissionAmount'],
+    group: 'Orders',
+    description: 'Per-vendor order segments. Vendors fulfill their own sub-orders.',
+  },
+  hooks: {
+    beforeChange: [
+      ({ data, operation, originalDoc }) => {
+        if (operation !== 'update' || data?.status == null) return data
+        const from = (originalDoc as { status?: string } | undefined)?.status
+        validateSubOrderStatusTransition(from, data.status as string)
+        return data
+      },
+    ],
+    afterRead: [
+      async ({ doc, req }) => {
+        if (!doc || !doc.parentOrder) return doc
+        if (doc.parentOrderNumber) return doc
+        try {
+          const orderId = typeof doc.parentOrder === 'object' ? (doc.parentOrder as { id: string }).id : doc.parentOrder
+          const order = await req.payload.findByID({ collection: 'orders', id: orderId, depth: 0 })
+          ;(doc as { parentOrderNumber?: string }).parentOrderNumber = (order as { orderNumber?: string }).orderNumber
+        } catch {
+          // ignore
+        }
+        return doc
+      },
+    ],
+    afterChange: [
+      async ({ doc, previousDoc, operation, req }) => {
+        if (operation === 'create') return doc
+        const fromStatus = previousDoc?.status
+        const toStatus = doc.status
+
+        // Release inventory when sub-order is cancelled
+        if (toStatus === 'cancelled') {
+          const payload = req.payload
+          const subOrderId = doc.id
+          const { docs: itemDocs } = await payload.find({
+            collection: 'order-items',
+            where: { subOrder: { equals: subOrderId } },
+            limit: 1000,
+            depth: 1,
+          })
+          await releaseOrderInventory(payload, itemDocs as OrderItemLike[], req)
+        }
+
+        // Consume inventory when sub-order is shipped (decrement quantity + reservedQuantity)
+        const alreadyShipped = ['shipped', 'delivered', 'completed'].includes(fromStatus ?? '')
+        if (toStatus === 'shipped' && !alreadyShipped) {
+          const payload = req.payload
+          const subOrderId = doc.id
+          const { docs: itemDocs } = await payload.find({
+            collection: 'order-items',
+            where: { subOrder: { equals: subOrderId } },
+            limit: 1000,
+            depth: 1,
+          })
+          await consumeOrderInventory(payload, itemDocs as OrderItemLike[], req)
+        }
+      },
+      async ({ doc, previousDoc, operation, req }) => {
+        if (operation === 'create') return doc
+        const fromStatus = previousDoc?.status
+        const toStatus = doc.status
+        if (!fromStatus || !toStatus || fromStatus === toStatus) return doc
+
+        const payload = req.payload
+        const parentOrderId = typeof doc.parentOrder === 'object' ? (doc.parentOrder as { id: string }).id : doc.parentOrder
+        if (!parentOrderId) return doc
+
+        // Derive parent order status from sub-order statuses.
+        // Use doc.status for the current sub-order (avoids read-after-write inconsistency).
+        const { docs: subOrders } = await payload.find({
+          collection: 'sub-orders',
+          where: { parentOrder: { equals: parentOrderId } },
+          limit: 100,
+          depth: 0,
+        })
+
+        const statuses = (subOrders as Array<{ id: string; status?: string }>).map((so) =>
+          so.id === doc.id ? (doc.status as string) : so.status
+        ).filter(Boolean) as string[]
+
+        // Industry standard: "shipped" = all sub-orders shipped; "partially-shipped" = only some.
+        // Active = sub-orders not cancelled/refunded. We require ALL active to be at that stage.
+        const strategy = (process.env.PARENT_ORDER_STATUS_STRATEGY ?? 'fulfillment-only').toLowerCase()
+        const fulfillmentOnly = strategy !== 'strict'
+        const active = statuses.filter((s) => s !== 'cancelled' && s !== 'refunded')
+        const hasCancelledOrRefunded = statuses.some((s) => s === 'cancelled' || s === 'refunded')
+
+        let newParentStatus: string | undefined
+        if (statuses.length && statuses.every((s) => s === 'cancelled' || s === 'refunded')) {
+          newParentStatus = 'cancelled'
+        } else if (active.length === 0) {
+          // None active (all cancelled/refunded or no statuses) — leave parent as-is
+        } else if (!fulfillmentOnly && hasCancelledOrRefunded) {
+          newParentStatus = 'partially-shipped'
+        } else if (active.every((s) => s === 'completed')) {
+          newParentStatus = 'completed'
+        } else if (active.every((s) => s === 'delivered' || s === 'completed')) {
+          newParentStatus = 'delivered'
+        } else if (active.every((s) => ['shipped', 'delivered', 'completed'].includes(s))) {
+          newParentStatus = 'shipped'
+        } else if (active.some((s) => ['shipped', 'delivered', 'completed'].includes(s))) {
+          newParentStatus = 'partially-shipped'
+        }
+
+        if (newParentStatus) {
+          await payload.update({
+            collection: 'orders',
+            id: parentOrderId,
+            overrideAccess: true,
+            data: { status: newParentStatus },
+            req,
+          })
+        }
+        return doc
+      },
+    ],
+  },
+  access: {
+    create: isAdmin, // Only created via process-checkout
+    read: ({ req }) => {
+      if (!req.user) return false
+      if (req.user.role === 'admin') return true
+      if (req.user.role === 'vendor' && req.user.tenant) {
+        const tenantId = typeof req.user.tenant === 'object' ? req.user.tenant.id : req.user.tenant
+        return { tenant: { equals: tenantId } }
+      }
+      return false
+    },
+    update: isAdminOrVendorOwner,
+    delete: () => false, // Sub-orders follow parent order lifecycle
+  },
+  fields: [
+    {
+      name: 'parentOrder',
+      type: 'relationship',
+      relationTo: 'orders',
+      required: true,
+      admin: {
+        description: 'Parent customer order.',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'parentOrderNumber',
+      type: 'text',
+      admin: {
+        description: 'Parent order number for display (e.g. ORD-20260302-ABCD). Auto-set on create.',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      required: true,
+      admin: { description: 'Vendor fulfilling this segment.' },
+    },
+    {
+      name: 'subOrderNumber',
+      type: 'text',
+      required: true,
+      unique: true,
+      admin: { description: 'e.g. ORD-20260217-XXXX-A' },
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'pending',
+      options: subOrderStatusOptions,
+    },
+    {
+      name: 'items',
+      type: 'relationship',
+      relationTo: 'order-items',
+      hasMany: true,
+      admin: { description: 'Order items for this vendor.' },
+    },
+    { name: 'subtotal', type: 'number', required: true, defaultValue: 0 },
+    { name: 'shippingTotal', type: 'number', required: true, defaultValue: 0 },
+    { name: 'taxTotal', type: 'number', required: true, defaultValue: 0 },
+    {
+      name: 'commissionAmount',
+      type: 'number',
+      required: true,
+      defaultValue: 0,
+      admin: { description: 'Platform fee for this sub-order.' },
+    },
+    {
+      name: 'commissionRate',
+      type: 'number',
+      admin: { description: 'Snapshot of rate at order time.' },
+    },
+    {
+      name: 'vendorEarnings',
+      type: 'number',
+      required: true,
+      defaultValue: 0,
+      admin: { description: 'subtotal - commissionAmount.' },
+    },
+    { name: 'shippingMethod', type: 'text' },
+    { name: 'trackingNumber', type: 'text' },
+    { name: 'trackingUrl', type: 'text' },
+    { name: 'shippedAt', type: 'date' },
+    { name: 'deliveredAt', type: 'date' },
+    {
+      name: 'fulfilledBy',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: { description: 'Vendor user who processed shipment.' },
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/orders/index.ts
+++ b/packages/backend/src/plugins/orders/index.ts
@@ -1,27 +1,34 @@
 import type { Plugin } from 'payload'
-import { Orders } from './collections/orders'
-import { OrderItems } from './collections/order-items'
+import { createOrdersConfig } from './collections/orders'
+import { createOrderItemsConfig } from './collections/order-items'
 import { OrderStatusHistory } from './collections/order-status-history'
+import { SubOrders } from './collections/sub-orders'
 
 export interface OrdersPluginOptions {
   enabled?: boolean
-  splitByVendor?: boolean // Phase 5: sub-orders. Phase 3: false
+  /** Phase 5: when true, create sub-orders per vendor. Requires MULTIVENDOR_ENABLED. */
+  splitByVendor?: boolean
   orderStateMachine?: string
 }
 
 export const ordersPlugin =
   (options: OrdersPluginOptions = {}): Plugin =>
   (incomingConfig) => {
-    const { enabled = true } = options
+    const { enabled = true, splitByVendor = false } = options
     if (!enabled) return incomingConfig
+
+    const collections = [
+      ...(incomingConfig.collections || []),
+      createOrderItemsConfig(splitByVendor),
+      OrderStatusHistory,
+      createOrdersConfig(splitByVendor),
+    ]
+    if (splitByVendor) {
+      collections.push(SubOrders)
+    }
 
     return {
       ...incomingConfig,
-      collections: [
-        ...(incomingConfig.collections || []),
-        OrderItems,
-        OrderStatusHistory,
-        Orders,
-      ],
+      collections,
     }
   }

--- a/packages/backend/src/plugins/orders/strategies/order-splitter.ts
+++ b/packages/backend/src/plugins/orders/strategies/order-splitter.ts
@@ -1,0 +1,70 @@
+/**
+ * Order splitting strategy — splits cart items by vendor into sub-orders.
+ * See docs/MULTIVENDOR-ARCHITECTURE.md §8 Strategy Patterns.
+ */
+
+export interface CartItemForSplit {
+  productId: string
+  variantId: string | null
+  productName: string
+  variantName: string
+  sku: string
+  quantity: number
+  unitPrice: number
+  totalPrice: number
+  productImage: string
+  /** Vendor (tenant) ID. Null = platform-owned product. */
+  tenantId: string | null
+}
+
+export interface SubOrderSegment {
+  tenantId: string
+  items: CartItemForSplit[]
+  subtotal: number
+}
+
+export interface OrderSplitterStrategy {
+  /**
+   * Group cart items by vendor. Returns segments, one per vendor.
+   * Platform-owned items (tenantId null) go to a single "platform" segment if present.
+   */
+  split(items: CartItemForSplit[]): SubOrderSegment[]
+}
+
+/**
+ * Default implementation: split by vendor (tenant).
+ * Each vendor gets one sub-order segment.
+ * Platform products (tenantId null) are excluded — they become order-items without sub-order.
+ */
+export class DefaultOrderSplitter implements OrderSplitterStrategy {
+  /** Items with this tenantId are excluded from sub-orders (platform-owned). */
+  static readonly PLATFORM_TENANT_ID = '__platform__'
+
+  split(items: CartItemForSplit[]): SubOrderSegment[] {
+    const byTenant = new Map<string, { items: CartItemForSplit[]; subtotal: number }>()
+
+    for (const item of items) {
+      if (!item.tenantId) continue // Skip platform items — no sub-order
+      const tid = item.tenantId
+      const existing = byTenant.get(tid)
+      if (existing) {
+        existing.items.push(item)
+        existing.subtotal += item.totalPrice
+      } else {
+        byTenant.set(tid, { items: [item], subtotal: item.totalPrice })
+      }
+    }
+
+    return Array.from(byTenant.entries()).map(([tenantId, { items: segItems, subtotal }]) => ({
+      tenantId,
+      items: segItems,
+      subtotal: Math.round(subtotal * 100) / 100,
+    }))
+  }
+}
+
+/** Platform items (tenantId null) — create as order-items without sub-order. */
+export function getPlatformItems(items: CartItemForSplit[]): CartItemForSplit[] {
+  return items.filter((i) => !i.tenantId)
+}
+

--- a/packages/backend/src/plugins/payouts/collections/payout-items.ts
+++ b/packages/backend/src/plugins/payouts/collections/payout-items.ts
@@ -1,0 +1,49 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
+
+/**
+ * Payout Items — line items linking sub-orders to payouts.
+ */
+export const PayoutItems: CollectionConfig = {
+  slug: 'payout-items',
+  admin: {
+    useAsTitle: 'orderNumber',
+    defaultColumns: ['payout', 'subOrder', 'orderNumber', 'amount', 'commission', 'status'],
+    group: 'Payouts',
+  },
+  access: {
+    create: isAdmin,
+    read: isAdminOrVendorOwner,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'payout',
+      type: 'relationship',
+      relationTo: 'payouts',
+      required: true,
+    },
+    {
+      name: 'subOrder',
+      type: 'relationship',
+      relationTo: 'sub-orders',
+      required: true,
+    },
+    { name: 'orderNumber', type: 'text', admin: { description: 'For reference.' } },
+    { name: 'amount', type: 'number', required: true },
+    { name: 'commission', type: 'number', required: true, defaultValue: 0 },
+    {
+      name: 'status',
+      type: 'select',
+      defaultValue: 'included',
+      options: [
+        { label: 'Included', value: 'included' },
+        { label: 'Held', value: 'held' },
+        { label: 'Disputed', value: 'disputed' },
+      ],
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/payouts/collections/payouts.ts
+++ b/packages/backend/src/plugins/payouts/collections/payouts.ts
@@ -1,0 +1,72 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
+
+/**
+ * Payouts — vendor earnings disbursement records.
+ * Manual ledger default (SSLCommerz no split payments).
+ */
+export const Payouts: CollectionConfig = {
+  slug: 'payouts',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['tenant', 'periodStart', 'periodEnd', 'netAmount', 'status', 'processedAt'],
+    group: 'Payouts',
+    description: 'Vendor payout records. Admin disburses manually or via bank transfer.',
+  },
+  access: {
+    create: isAdmin,
+    read: ({ req }) => {
+      if (!req.user) return false
+      if (req.user.role === 'admin') return true
+      if (req.user.role === 'vendor' && req.user.tenant) {
+        const tenantId = typeof req.user.tenant === 'object' ? req.user.tenant.id : req.user.tenant
+        return { tenant: { equals: tenantId } }
+      }
+      return false
+    },
+    update: isAdmin,
+    delete: () => false,
+  },
+  fields: [
+    {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      required: true,
+    },
+    { name: 'periodStart', type: 'date', required: true },
+    { name: 'periodEnd', type: 'date', required: true },
+    { name: 'totalEarnings', type: 'number', required: true, defaultValue: 0 },
+    { name: 'totalCommission', type: 'number', required: true, defaultValue: 0 },
+    { name: 'netAmount', type: 'number', required: true, defaultValue: 0 },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'pending',
+      options: [
+        { label: 'Pending', value: 'pending' },
+        { label: 'Processing', value: 'processing' },
+        { label: 'Completed', value: 'completed' },
+        { label: 'Failed', value: 'failed' },
+        { label: 'On Hold', value: 'on-hold' },
+      ],
+    },
+    {
+      name: 'method',
+      type: 'text',
+      admin: { description: 'e.g. stripe-transfer, bank-transfer, manual' },
+    },
+    { name: 'providerPayoutId', type: 'text' },
+    {
+      name: 'items',
+      type: 'relationship',
+      relationTo: 'payout-items',
+      hasMany: true,
+    },
+    { name: 'processedAt', type: 'date' },
+    { name: 'notes', type: 'textarea' },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/payouts/index.ts
+++ b/packages/backend/src/plugins/payouts/index.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from 'payload'
+import { Payouts } from './collections/payouts'
+import { PayoutItems } from './collections/payout-items'
+
+export interface PayoutsPluginOptions {
+  enabled?: boolean
+  schedule?: string
+  holdDays?: number
+  adapter?: 'manual-ledger' | 'stripe-transfer'
+}
+
+/**
+ * Payouts plugin — vendor earnings tracking and disbursement.
+ * Manual ledger default. Admin creates payouts from delivered sub-orders.
+ */
+export const payoutsPlugin =
+  (options: PayoutsPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = false } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [
+        ...(incomingConfig.collections || []),
+        PayoutItems, // Must be before Payouts (relationship)
+        Payouts,
+      ],
+    }
+  }


### PR DESCRIPTION
## Phase 5:  Multivendor Commerce

### Summary

Adds backend multivendor commerce: sub-orders per vendor, commission calculation, payouts, order status flow, and inventory consume on ship. Manual ledger and single checkout unchanged; Stripe Connect and automated payouts deferred.

### Implemented

**Orders**
- **SubOrders** collection: per-vendor segments with status, commissionAmount, vendorEarnings, parentOrderNumber
- **Order splitting**: by tenant; platform items become order-items without sub-order
- **Parent order status**: Derived from sub-orders (all active shipped → shipped; all completed → completed; configurable `PARENT_ORDER_STATUS_STRATEGY`: `fulfillment-only` | `strict`)
- **Status flow**: Validated transitions (no cancel after ship); invalid change returns 400 with allowed next statuses
- **Vendor access**: Vendors read parent orders that contain their sub-orders; order-items read for own tenant (fixes admin relationship labels)

**Checkout & commission**
- **process-checkout**: When `MULTIVENDOR_ENABLED`, creates sub-orders per vendor with commission (VendorSettings or `DEFAULT_COMMISSION_RATE`), sets parentOrderNumber, reserves inventory
- **lib/commission**: getCommissionRateForTenant, calculateCommission (percentage); CommissionRules collection for future use

**Payouts**
- **Payouts** and **PayoutItems**; manual ledger; vendor read own tenant

**Inventory**
- Reserve at checkout; release on order/sub-order cancel; consume (quantity + reservedQuantity) on order/sub-order shipped

**Cart**
- Cart items get `vendor` (tenant) when multivendor enabled for storefront grouping

**API**
- OpenAPI 0.5.0: status validation, vendor access, 400 responses for invalid transitions

### Deferred (Phase 5.1+)

- Stripe Connect / split payments
- Automated payout execution (scheduled job + adapter)
- Storefront multi-vendor cart grouping and per-vendor shipping (separate repo)
- Full CommissionRules integration in checkout

### Env vars

`MULTIVENDOR_ENABLED`, `DEFAULT_COMMISSION_RATE`, `PAYOUT_*`, optional `PARENT_ORDER_STATUS_STRATEGY`. See backend `.env.example`.