### PR TITLE
feat(verification): Phase 6.1 - Identifier verification (email) (link + OTP)

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -145,6 +145,20 @@ SMTP_PASS=your-smtp-password
 # TWILIO_FROM_NUMBER=+1234567890
 
 # ═══════════════════════════════════════════════════
+# VERIFICATION (Phase 6.1 — Identifier verification)
+# See docs/IDENTIFIER-VERIFICATION-BACKLOG.md
+# ═══════════════════════════════════════════════════
+VERIFICATION_ENABLED=true
+# Email: link = one-click URL in email; otp = code in email
+EMAIL_VERIFICATION_STRATEGY=link
+# Link: token expiry (minutes). OTP: code expiry (seconds)
+EMAIL_VERIFICATION_TOKEN_EXPIRY_MINUTES=30
+EMAIL_VERIFICATION_OTP_EXPIRY=300
+EMAIL_VERIFICATION_OTP_LENGTH=6
+# Base URL for verification link (default: NEXT_PUBLIC_APP_URL)
+# VERIFICATION_BASE_URL=http://localhost:3000
+
+# ═══════════════════════════════════════════════════
 # ANALYTICS
 # ═══════════════════════════════════════════════════
 ANALYTICS_ENABLED=true

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -23,6 +23,7 @@ import { ordersPlugin } from './plugins/orders'
 import { commissionsPlugin } from './plugins/commissions'
 import { payoutsPlugin } from './plugins/payouts'
 import { notificationsPlugin } from './plugins/notifications'
+import { verificationPlugin } from './plugins/verification'
 
 import { Header } from './globals/header'
 import { Footer } from './globals/footer'
@@ -231,6 +232,12 @@ export default buildConfig({
         email: (process.env.EMAIL_ADAPTER as 'smtp' | 'resend') || 'smtp',
         sms: process.env.SMS_ADAPTER,
       },
+    }),
+
+    // Phase 6.1: Identifier verification (email link/OTP)
+    verificationPlugin({
+      enabled: process.env.VERIFICATION_ENABLED !== 'false',
+      emailStrategy: (process.env.EMAIL_VERIFICATION_STRATEGY as 'link' | 'otp') || 'link',
     }),
 
     // Future plugins (added per phase):

--- a/packages/backend/src/plugins/notifications/lib/send-email.ts
+++ b/packages/backend/src/plugins/notifications/lib/send-email.ts
@@ -20,7 +20,10 @@ export async function sendEmail(options: SendEmailOptions): Promise<boolean> {
     console.log('[Notifications] SMTP configured but nodemailer not yet integrated. Logging email:')
   }
 
-  console.log('[Notifications] Email:', { to, subject, preview: (text || html || '').slice(0, 100) })
+  const content = text || html || ''
+  // Verification links need full URL (token ~43 chars); avoid truncating so testers can copy from preview
+  const previewLength = content.includes('verify-email/') ? 200 : 100
+  console.log('[Notifications] Email:', { to, subject, preview: content.slice(0, previewLength) })
   return true
 }
 

--- a/packages/backend/src/plugins/verification/adapters/email-link.ts
+++ b/packages/backend/src/plugins/verification/adapters/email-link.ts
@@ -1,0 +1,32 @@
+/**
+ * Email verification: link strategy.
+ * Sends a one-click link; user verifies via GET /api/auth/verify-email/:token.
+ */
+import { sendEmail } from '../../notifications/lib/send-email'
+
+const DEFAULT_EXPIRY_MINUTES = 30
+
+export async function sendVerificationLink(
+  email: string,
+  token: string,
+  expiryMinutes: number = DEFAULT_EXPIRY_MINUTES
+): Promise<boolean> {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.VERIFICATION_BASE_URL || 'http://localhost:3000'
+  const verifyUrl = `${baseUrl.replace(/\/$/, '')}/api/auth/verify-email/${token}`
+
+  const subject = 'Verify your email address'
+  const html = `
+    <p>Please verify your email by clicking the link below.</p>
+    <p><a href="${verifyUrl}">Verify email</a></p>
+    <p>This link expires in ${expiryMinutes} minutes. If you didn't request this, you can ignore this email.</p>
+  `
+  const text = `Verify your email: ${verifyUrl}\n\nThis link expires in ${expiryMinutes} minutes.`
+
+  // Log full link/token only in non-production so testers can copy when email is console-only
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('[Verification] Full link — copy the token (after the last /) for POST /api/auth/verify-email:', verifyUrl)
+    console.log('[Verification] Token only:', token)
+  }
+
+  return sendEmail({ to: email, subject, html, text })
+}

--- a/packages/backend/src/plugins/verification/adapters/email-otp.ts
+++ b/packages/backend/src/plugins/verification/adapters/email-otp.ts
@@ -1,0 +1,20 @@
+/**
+ * Email verification: OTP strategy.
+ * Sends a numeric code; user verifies via POST /api/auth/verify-email with code + email.
+ */
+import { sendEmail } from '../../notifications/lib/send-email'
+
+export async function sendVerificationOTP(
+  email: string,
+  code: string,
+  expirySeconds: number
+): Promise<boolean> {
+  const subject = 'Your verification code'
+  const html = `
+    <p>Your verification code is: <strong>${code}</strong></p>
+    <p>It expires in ${Math.ceil(expirySeconds / 60)} minutes. Do not share this code.</p>
+  `
+  const text = `Your verification code is: ${code}. It expires in ${Math.ceil(expirySeconds / 60)} minutes.`
+
+  return sendEmail({ to: email, subject, html, text })
+}

--- a/packages/backend/src/plugins/verification/collections/verification-codes.ts
+++ b/packages/backend/src/plugins/verification/collections/verification-codes.ts
@@ -1,0 +1,62 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+/**
+ * Stores verification codes/tokens for email and phone verification.
+ * Single-use; expires after configured time. Admin can read for support.
+ */
+export const VerificationCodes: CollectionConfig = {
+  slug: 'verification-codes',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['identifier', 'type', 'used', 'expiresAt', 'createdAt'],
+    group: 'Platform',
+    description: 'Email/phone verification codes and tokens. Single-use, auto-expire.',
+  },
+  access: {
+    create: () => false, // Only created by verification endpoints
+    read: isAdmin,
+    update: () => false,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'identifier',
+      type: 'text',
+      required: true,
+      admin: { description: 'Email address or phone number.' },
+    },
+    {
+      name: 'type',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Email', value: 'email' },
+        { label: 'Phone', value: 'phone' },
+      ],
+    },
+    {
+      name: 'code',
+      type: 'text',
+      required: true,
+      admin: { description: 'OTP code or link token (hashed or plain per strategy).' },
+    },
+    {
+      name: 'expiresAt',
+      type: 'date',
+      required: true,
+      admin: { description: 'After this time the code is invalid.' },
+    },
+    {
+      name: 'used',
+      type: 'checkbox',
+      defaultValue: false,
+    },
+    {
+      name: 'usedAt',
+      type: 'date',
+      admin: { description: 'When the code was consumed.' },
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/verification/endpoints/send-verification.ts
+++ b/packages/backend/src/plugins/verification/endpoints/send-verification.ts
@@ -1,0 +1,148 @@
+/**
+ * POST /api/auth/send-verification
+ * Sends a verification code or link to the given email or phone.
+ * Optional auth: if authenticated, identifier must match user's email or phone.
+ * Rate limit: 60s cooldown per identifier.
+ */
+import type { Endpoint } from 'payload'
+import { sendVerificationLink } from '../adapters/email-link'
+import { sendVerificationOTP } from '../adapters/email-otp'
+import { generateVerificationToken, generateOTP } from '../lib/generate-code'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const COOLDOWN_MS = 60 * 1000 // 60 seconds
+const DEFAULT_EMAIL_TOKEN_EXPIRY_MINUTES = 30
+const DEFAULT_OTP_EXPIRY_SECONDS = 300
+
+function getEmailStrategy(): 'link' | 'otp' {
+  const v = process.env.EMAIL_VERIFICATION_STRATEGY?.toLowerCase()
+  return v === 'otp' ? 'otp' : 'link'
+}
+
+function getOTPLength(): number {
+  const n = parseInt(process.env.EMAIL_VERIFICATION_OTP_LENGTH || '6', 10)
+  return Number.isFinite(n) && n >= 4 && n <= 8 ? n : 6
+}
+
+export const sendVerificationEndpoint: Endpoint = {
+  path: '/auth/send-verification',
+  method: 'post',
+  handler: async (req) => {
+    const data = (await (req as Request).json?.().catch(() => ({}))) || {}
+    const { identifierType, identifier } = data
+
+    if (!identifierType || !identifier || typeof identifier !== 'string') {
+      return Response.json(
+        { error: 'identifierType (email|phone) and identifier are required.' },
+        { status: 400 }
+      )
+    }
+
+    const idType = String(identifierType).toLowerCase()
+    if (idType !== 'email' && idType !== 'phone') {
+      return Response.json(
+        { error: 'identifierType must be email or phone.' },
+        { status: 400 }
+      )
+    }
+
+    const trimmed = String(identifier).trim()
+    if (idType === 'email') {
+      if (!EMAIL_REGEX.test(trimmed)) {
+        return Response.json({ error: 'Invalid email address.' }, { status: 400 })
+      }
+    }
+    // Phone: accept any non-empty string for now
+
+    if (idType === 'phone') {
+      return Response.json(
+        { error: 'Phone verification is not yet implemented (Phase 6.2).' },
+        { status: 501 }
+      )
+    }
+
+    // Optional: require auth and that identifier belongs to user
+    const user = req.user
+    if (user?.email && trimmed.toLowerCase() !== String(user.email).trim().toLowerCase()) {
+      return Response.json(
+        { error: 'Identifier does not match the authenticated user.' },
+        { status: 403 }
+      )
+    }
+
+    const payload = req.payload
+
+    // Cooldown: last code for this identifier within 60s
+    const { docs } = await payload.find({
+      collection: 'verification-codes',
+      where: {
+        identifier: { equals: trimmed },
+        type: { equals: 'email' },
+      },
+      limit: 1,
+      sort: '-createdAt',
+      req,
+      overrideAccess: true,
+    })
+    const last = docs[0]
+    if (last?.createdAt) {
+      const created = new Date(last.createdAt).getTime()
+      if (Date.now() - created < COOLDOWN_MS) {
+        return Response.json(
+          { error: 'Please wait before requesting another code.', retryAfter: 60 },
+          { status: 429 }
+        )
+      }
+    }
+
+    const strategy = getEmailStrategy()
+    const expiresAt = new Date()
+
+    if (strategy === 'link') {
+      const token = generateVerificationToken()
+      const expiryMinutes = parseInt(process.env.EMAIL_VERIFICATION_TOKEN_EXPIRY_MINUTES || String(DEFAULT_EMAIL_TOKEN_EXPIRY_MINUTES), 10) || DEFAULT_EMAIL_TOKEN_EXPIRY_MINUTES
+      expiresAt.setMinutes(expiresAt.getMinutes() + expiryMinutes)
+
+      await payload.create({
+        collection: 'verification-codes',
+        data: {
+          identifier: trimmed,
+          type: 'email',
+          code: token,
+          expiresAt: expiresAt.toISOString(),
+        },
+        req,
+        overrideAccess: true,
+      })
+
+      const sent = await sendVerificationLink(trimmed, token, expiryMinutes)
+      if (!sent) {
+        return Response.json({ error: 'Failed to send verification email.' }, { status: 502 })
+      }
+      return Response.json({ success: true, message: 'Verification link sent to your email.' })
+    }
+
+    // OTP
+    const code = generateOTP(getOTPLength())
+    const expirySeconds = parseInt(process.env.EMAIL_VERIFICATION_OTP_EXPIRY || String(DEFAULT_OTP_EXPIRY_SECONDS), 10) || DEFAULT_OTP_EXPIRY_SECONDS
+    expiresAt.setSeconds(expiresAt.getSeconds() + expirySeconds)
+
+    await payload.create({
+      collection: 'verification-codes',
+      data: {
+        identifier: trimmed,
+        type: 'email',
+        code,
+        expiresAt: expiresAt.toISOString(),
+      },
+      req,
+      overrideAccess: true,
+    })
+
+    const sent = await sendVerificationOTP(trimmed, code, expirySeconds)
+    if (!sent) {
+      return Response.json({ error: 'Failed to send verification code.' }, { status: 502 })
+    }
+    return Response.json({ success: true, message: 'Verification code sent to your email.' })
+  },
+}

--- a/packages/backend/src/plugins/verification/endpoints/verify-email.ts
+++ b/packages/backend/src/plugins/verification/endpoints/verify-email.ts
@@ -1,0 +1,143 @@
+/**
+ * POST /api/auth/verify-email
+ * Verifies email using token (link strategy) or code + email (OTP strategy).
+ * On success, sets user.emailVerified = true for the user with that email.
+ */
+import type { Endpoint } from 'payload'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export const verifyEmailEndpoint: Endpoint = {
+  path: '/auth/verify-email',
+  method: 'post',
+  handler: async (req) => {
+    const data = (await (req as Request).json?.().catch(() => ({}))) || {}
+    const { token, code, email } = data
+
+    const payload = req.payload
+
+    // Link strategy: token in body (e.g. from frontend page that got ?token= from URL)
+    if (token && typeof token === 'string' && token.trim()) {
+      const t = token.trim()
+      const { docs } = await payload.find({
+        collection: 'verification-codes',
+        where: {
+          type: { equals: 'email' },
+          code: { equals: t },
+          used: { equals: false },
+        },
+        limit: 1,
+        req,
+        overrideAccess: true,
+      })
+      const record = docs[0]
+      if (!record) {
+        return Response.json(
+          { error: 'Invalid or expired verification link.' },
+          { status: 400 }
+        )
+      }
+      const expiresAt = record.expiresAt ? new Date(record.expiresAt).getTime() : 0
+      if (Date.now() > expiresAt) {
+        return Response.json(
+          { error: 'Verification link has expired. Please request a new one.' },
+          { status: 400 }
+        )
+      }
+
+      await payload.update({
+        collection: 'verification-codes',
+        id: record.id,
+        data: { used: true, usedAt: new Date().toISOString() },
+        req,
+        overrideAccess: true,
+      })
+
+      const identifier = String(record.identifier).trim().toLowerCase()
+      const { docs: users } = await payload.find({
+        collection: 'users',
+        where: { email: { equals: identifier } },
+        limit: 1,
+      })
+      const user = users[0]
+      if (user) {
+        await payload.update({
+          collection: 'users',
+          id: user.id,
+          data: { emailVerified: true },
+          req,
+          overrideAccess: true,
+        })
+      }
+
+      return Response.json({ success: true, message: 'Email verified.' })
+    }
+
+    // OTP strategy: code + email
+    if (code && email && typeof code === 'string' && typeof email === 'string') {
+      const emailTrimmed = email.trim().toLowerCase()
+      if (!EMAIL_REGEX.test(emailTrimmed)) {
+        return Response.json({ error: 'Invalid email address.' }, { status: 400 })
+      }
+      const codeTrimmed = code.trim()
+
+      const { docs } = await payload.find({
+        collection: 'verification-codes',
+        where: {
+          type: { equals: 'email' },
+          identifier: { equals: emailTrimmed },
+          code: { equals: codeTrimmed },
+          used: { equals: false },
+        },
+        limit: 1,
+        req,
+        overrideAccess: true,
+      })
+      const record = docs[0]
+      if (!record) {
+        return Response.json(
+          { error: 'Invalid or expired verification code.' },
+          { status: 400 }
+        )
+      }
+      const expiresAt = record.expiresAt ? new Date(record.expiresAt).getTime() : 0
+      if (Date.now() > expiresAt) {
+        return Response.json(
+          { error: 'Verification code has expired. Please request a new one.' },
+          { status: 400 }
+        )
+      }
+
+      await payload.update({
+        collection: 'verification-codes',
+        id: record.id,
+        data: { used: true, usedAt: new Date().toISOString() },
+        req,
+        overrideAccess: true,
+      })
+
+      const { docs: users } = await payload.find({
+        collection: 'users',
+        where: { email: { equals: emailTrimmed } },
+        limit: 1,
+      })
+      const user = users[0]
+      if (user) {
+        await payload.update({
+          collection: 'users',
+          id: user.id,
+          data: { emailVerified: true },
+          req,
+          overrideAccess: true,
+        })
+      }
+
+      return Response.json({ success: true, message: 'Email verified.' })
+    }
+
+    return Response.json(
+      { error: 'Provide either token (link) or code and email (OTP).' },
+      { status: 400 }
+    )
+  },
+}

--- a/packages/backend/src/plugins/verification/index.ts
+++ b/packages/backend/src/plugins/verification/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Phase 6.1 — Identifier verification plugin.
+ * Email: link or OTP strategy (EMAIL_VERIFICATION_STRATEGY=link|otp).
+ * Phone: Phase 6.2 (adapters and endpoints TBD).
+ * See docs/IDENTIFIER-VERIFICATION-BACKLOG.md.
+ */
+import type { Plugin } from 'payload'
+import { VerificationCodes } from './collections/verification-codes'
+import { sendVerificationEndpoint } from './endpoints/send-verification'
+import { verifyEmailEndpoint } from './endpoints/verify-email'
+
+export interface VerificationPluginOptions {
+  /** Enable the plugin. Default true. */
+  enabled?: boolean
+  /** Email strategy: link (one-click URL) or otp (code in email). Default from env EMAIL_VERIFICATION_STRATEGY. */
+  emailStrategy?: 'link' | 'otp'
+}
+
+export const verificationPlugin =
+  (options: VerificationPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    const collections = [...(incomingConfig.collections || []), VerificationCodes]
+    const endpoints = [
+      ...(incomingConfig.endpoints || []),
+      sendVerificationEndpoint,
+      verifyEmailEndpoint,
+    ]
+
+    return {
+      ...incomingConfig,
+      collections,
+      endpoints,
+    }
+  }

--- a/packages/backend/src/plugins/verification/lib/generate-code.ts
+++ b/packages/backend/src/plugins/verification/lib/generate-code.ts
@@ -1,0 +1,20 @@
+import crypto from 'node:crypto'
+
+const EMAIL_LINK_TOKEN_BYTES = 32
+const OTP_DIGITS = 6
+
+/**
+ * Generate a secure random token for link-based verification (URL-safe, no padding).
+ */
+export function generateVerificationToken(): string {
+  return crypto.randomBytes(EMAIL_LINK_TOKEN_BYTES).toString('base64url')
+}
+
+/**
+ * Generate a numeric OTP of given length (default 6). Not zero-padded for display.
+ */
+export function generateOTP(length: number = OTP_DIGITS): string {
+  const max = 10 ** length - 1
+  const n = crypto.randomInt(0, max + 1)
+  return n.toString().padStart(length, '0')
+}


### PR DESCRIPTION
## Phase 6.1 — Identifier verification (email)

Implements pluggable email verification for Phase 6 (Advanced Features): link-based and OTP-based flows, with config and backlog updates for deferred work.

### Implemented

- **Verification plugin** (`src/plugins/verification/`)
  - `verification-codes` collection (identifier, type, code, expiresAt, used)
  - `POST /api/auth/send-verification` — send link or OTP to email (optional auth; 60s cooldown per identifier)
  - `POST /api/auth/verify-email` — verify by `token` (link) or `code` + `email` (OTP); sets `user.emailVerified`
  - Adapters: email-link (uses notifications `sendEmail`), email-otp
  - Config: `VERIFICATION_ENABLED`, `EMAIL_VERIFICATION_STRATEGY=link|otp`, expiry/length env vars
- **Security / UX**
  - Token/link logged only when `NODE_ENV !== 'production'`
  - Notification preview extended to 200 chars for verification URLs so console preview is not truncated
- **Docs**
  - OpenAPI: `/auth/send-verification`, `/auth/verify-email`, `/verification-codes` (admin)
  - `IDENTIFIER-VERIFICATION-BACKLOG.md` and `PHASE-6-START.md` updated; remaining items deferred
  - `PHASE-6-TEST-PROCEDURE.md` for setup and testing
- **Env:** `.env.example` updated with `VERIFICATION_*` and `EMAIL_VERIFICATION_*`

### Deferred (backlog)

- GET `/api/auth/verify-email/:token` (one-click from email)
- Optional: block login until verified, require verification before checkout
- Rate limiting per identifier/IP
- Admin polish; Phase 6.2 phone verification

### Testing

- See `docs/PHASE-6-TEST-PROCEDURE.md`. Backend requires Postgres + Redis; verification works with console-only email (no SMTP).

**Target:** `revamp/multivendor`