### PR TITLE
feat(verification): Phase 6.2 — phone verification (OTP) + custom adapter

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -158,6 +158,23 @@ EMAIL_VERIFICATION_OTP_LENGTH=6
 # Base URL for verification link (default: NEXT_PUBLIC_APP_URL)
 # VERIFICATION_BASE_URL=http://localhost:3000
 
+# Phone (Phase 6.2): twilio | sslwireless | console | custom
+PHONE_VERIFICATION_PROVIDER=console
+PHONE_VERIFICATION_OTP_EXPIRY=300
+PHONE_VERIFICATION_OTP_LENGTH=6
+# Custom adapter (when PHONE_VERIFICATION_PROVIDER=custom). Path relative to process cwd.
+# Edit adapters/phone/example-phone-adapter.js and set:
+# VERIFICATION_PHONE_ADAPTER_PATH=./adapters/phone/example-phone-adapter.js
+# See adapters/phone/README.md for interface and complex logic / custom deps.
+# Twilio (when PHONE_VERIFICATION_PROVIDER=twilio)
+# TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# TWILIO_AUTH_TOKEN=your-twilio-auth-token
+# TWILIO_FROM_NUMBER=+1234567890
+# Or use Messaging Service: TWILIO_MESSAGING_SERVICE_SID=MGxxxx
+# SSL Wireless / Bangladesh (when PHONE_VERIFICATION_PROVIDER=sslwireless) — stub for now
+# SSLWIRELESS_API_KEY=...
+# SSLWIRELESS_SENDER=...
+
 # ═══════════════════════════════════════════════════
 # ANALYTICS
 # ═══════════════════════════════════════════════════

--- a/packages/backend/adapters/README.md
+++ b/packages/backend/adapters/README.md
@@ -1,0 +1,16 @@
+# Custom adapters
+
+Adapters are organized **by type** in subfolders. Each subfolder contains examples and documentation for that adapter type.
+
+| Subfolder | Purpose |
+|-----------|---------|
+| **phone/** | Phone verification (OTP) — custom SMS gateways when `PHONE_VERIFICATION_PROVIDER=custom`. |
+
+Future adapter types (e.g. email, notifications) can get their own subfolders here.
+
+---
+
+## Phone verification
+
+- **Quick start:** [adapters/phone/README.md](phone/README.md)
+- **Adapter:** Edit `phone/example-phone-adapter.js` (implement `sendOTP`), then set `VERIFICATION_PHONE_ADAPTER_PATH=./adapters/phone/example-phone-adapter.js` in `.env`.

--- a/packages/backend/adapters/phone/README.md
+++ b/packages/backend/adapters/phone/README.md
@@ -1,0 +1,100 @@
+# Custom phone verification adapter
+
+Use a **custom phone adapter** when you want to send OTP via your own SMS gateway (e.g. Vonage, AWS SNS, a local Bangladesh gateway, or an in-house API) instead of the built-in **Twilio** or **SSL Wireless** options.
+
+---
+
+## 1. Interface
+
+Your adapter module must export an object with a single method:
+
+| Method     | Signature                                                                 | Description                                        |
+|-----------|----------------------------------------------------------------------------|----------------------------------------------------|
+| `sendOTP` | `(phone: string, code: string, expirySeconds: number) => Promise<boolean>` | Send the OTP to `phone`. Return `true` on success. |
+
+- **phone** — Phone number (E.164 recommended, e.g. `+8801712345678`).
+- **code** — One-time code (e.g. 6 digits).
+- **expirySeconds** — Code validity in seconds; you can use this in the message text.
+
+Export as **default** or **named** export. CommonJS and ESM are both supported.
+
+**Minimal example:**
+
+```js
+async function sendOTP(phone, code, expirySeconds) {
+  // Call your SMS API
+  return true
+}
+module.exports = { sendOTP }
+module.exports.default = { sendOTP }
+```
+
+---
+
+## 2. Configuration
+
+In `.env`:
+
+```env
+PHONE_VERIFICATION_PROVIDER=custom
+VERIFICATION_PHONE_ADAPTER_PATH=./adapters/phone/example-phone-adapter.js
+```
+
+**VERIFICATION_PHONE_ADAPTER_PATH** is relative to the process current working directory (when running `yarn dev` from `packages/backend`, cwd is usually `packages/backend`).
+
+If the path is missing or the module fails to load, the plugin falls back to the **console** adapter (OTP only logged).
+
+---
+
+## 3. In-repo adapter (edit directly)
+
+The file **`example-phone-adapter.js`** in this folder is the template. Edit it directly:
+
+1. Implement `sendOTP` with your SMS gateway (replace the log-only stub).
+2. Use `process.env` for API keys (do not commit secrets).
+3. Set `VERIFICATION_PHONE_ADAPTER_PATH=./adapters/phone/example-phone-adapter.js` in `.env` (or your own filename if you rename/copy).
+4. Restart the backend (adapter is loaded once and cached).
+
+Keeping this file minimal and abstract makes it easy to fork the repo and implement your gateway in one place.
+
+---
+
+## 4. Complex logic and custom dependencies
+
+**Multiple files:** The adapter can `require()` or `import` other files (e.g. `./gateway-client.js`) in this folder. Node resolves relative imports from the adapter file’s location, so you can split logic across `adapters/phone/` as needed.
+
+**npm dependencies:** When the loaded module uses `require('some-package')` or `import 'some-package'`, Node resolves from the **main backend package** (the process that loaded the adapter). So:
+
+- **Option A — deps in backend:** Add any adapter-specific packages to `packages/backend/package.json` and use them in your adapter. Simple and fine for one custom adapter.
+- **Option B — separate package:** For a fully self-contained adapter (e.g. reusable across projects), implement it as its own npm package with its own `package.json` and dependencies. Publish or link it, install in the backend (`yarn add ./packages/my-phone-adapter` or similar), then set `VERIFICATION_PHONE_ADAPTER_PATH` to that package’s entry file (e.g. `./node_modules/my-phone-adapter/dist/index.js` or a path under `packages/` if using a monorepo).
+
+So: the in-repo file stays a thin, abstract stub; you can grow it with local files and backend-installed deps, or move to a separate package if you need isolated dependencies.
+
+---
+
+## 5. File layout (this repo)
+
+```
+packages/backend/
+├── adapters/
+│   ├── README.md
+│   └── phone/
+│       ├── README.md       ← This file
+│       └── example-phone-adapter.js   ← Edit this; point VERIFICATION_PHONE_ADAPTER_PATH here
+├── src/
+│   └── ...
+└── .env
+```
+
+---
+
+## 6. Testing
+
+- **Console only:** Keep the stub (log only). Set `PHONE_VERIFICATION_PROVIDER=custom` and `VERIFICATION_PHONE_ADAPTER_PATH=./adapters/phone/example-phone-adapter.js`. Trigger send-verification; OTP appears in the server log.
+- **Real gateway:** Implement `sendOTP`, then use `POST /api/auth/send-verification` (identifierType: phone) and `POST /api/auth/verify-phone` (code, phone).
+
+---
+
+## 7. Implementation reference
+
+- **Custom loader:** `src/plugins/verification/adapters/get-phone-adapter.ts` (loads and caches the module; fallback to console on error).

--- a/packages/backend/adapters/phone/example-phone-adapter.js
+++ b/packages/backend/adapters/phone/example-phone-adapter.js
@@ -1,0 +1,46 @@
+/**
+ * Custom phone verification adapter — edit this file to use your SMS gateway.
+ *
+ * Contract: export an object with sendOTP(phone, code, expirySeconds) => Promise<boolean>.
+ * Config: PHONE_VERIFICATION_PROVIDER=custom and
+ * VERIFICATION_PHONE_ADAPTER_PATH=./adapters/phone/example-phone-adapter.js
+ *
+ * For complex logic or custom npm dependencies, see adapters/phone/README.md.
+ */
+
+/**
+ * Sends an OTP to the given phone number.
+ *
+ * @param {string} phone - Phone number (E.164 recommended, e.g. +8801712345678).
+ * @param {string} code - One-time code (e.g. 6 digits).
+ * @param {number} expirySeconds - Code validity in seconds (for optional message text).
+ * @returns {Promise<boolean>} - true if send succeeded, false on failure.
+ */
+async function sendOTP(phone, code, expirySeconds) {
+  // -------------------------------------------------------------------------
+  // TODO: Replace with your SMS gateway (Twilio, Vonage, AWS SNS, local BD
+  //       gateways like SSL Wireless, muthofun, or your provider's HTTP API).
+  // -------------------------------------------------------------------------
+
+  // Example: log only (for local testing without a real gateway).
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('[Custom phone adapter] sendOTP:', { phone, code, expirySeconds })
+  }
+
+  // Example: call an HTTP API (uncomment and adjust for your provider).
+  // const res = await fetch('https://your-sms-gateway.com/send', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${process.env.MY_SMS_API_KEY}` },
+  //   body: JSON.stringify({ to: phone, message: `Your code is ${code}. Valid for ${Math.ceil(expirySeconds / 60)} min.` }),
+  // })
+  // if (!res.ok) {
+  //   console.error('[Custom phone adapter] Gateway error:', await res.text())
+  //   return false
+  // }
+  // return true
+
+  return true
+}
+
+module.exports = { sendOTP }
+module.exports.default = { sendOTP }

--- a/packages/backend/src/plugins/verification/adapters/get-phone-adapter.ts
+++ b/packages/backend/src/plugins/verification/adapters/get-phone-adapter.ts
@@ -1,0 +1,68 @@
+/**
+ * Phase 6.2 — Resolve phone verification adapter from PHONE_VERIFICATION_PROVIDER.
+ * When provider is "custom", loads adapter from VERIFICATION_PHONE_ADAPTER_PATH (relative to cwd).
+ */
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { PhoneVerificationAdapter } from './phone-types'
+import { phoneConsoleAdapter } from './phone-console'
+import { phoneTwilioAdapter } from './phone-twilio'
+import { phoneSSLWirelessAdapter } from './phone-sslwireless'
+
+export type PhoneProvider = 'twilio' | 'sslwireless' | 'console' | 'custom'
+
+let customAdapterCache: PhoneVerificationAdapter | null = null
+
+function isAdapter(obj: unknown): obj is PhoneVerificationAdapter {
+  return typeof obj === 'object' && obj !== null && typeof (obj as PhoneVerificationAdapter).sendOTP === 'function'
+}
+
+async function loadCustomAdapter(): Promise<PhoneVerificationAdapter> {
+  if (customAdapterCache) return customAdapterCache
+  const adapterPath = process.env.VERIFICATION_PHONE_ADAPTER_PATH
+  if (!adapterPath?.trim()) {
+    console.warn('[Verification] PHONE_VERIFICATION_PROVIDER=custom but VERIFICATION_PHONE_ADAPTER_PATH not set. Using console adapter.')
+    return phoneConsoleAdapter
+  }
+  try {
+    const resolved = path.resolve(process.cwd(), adapterPath.trim())
+    // ESM import() on Windows requires file:// URL; pathToFileURL handles all platforms
+    const fileUrl = pathToFileURL(resolved).href
+    const mod = await import(/* webpackIgnore: true */ fileUrl)
+    const adapter = mod?.default ?? mod
+    if (!isAdapter(adapter)) {
+      console.error('[Verification] Custom adapter must export default or named object with sendOTP(phone, code, expirySeconds). Using console adapter.')
+      return phoneConsoleAdapter
+    }
+    customAdapterCache = adapter
+    return adapter
+  } catch (err) {
+    console.error('[Verification] Failed to load custom phone adapter:', err)
+    return phoneConsoleAdapter
+  }
+}
+
+export function getPhoneAdapterSync(): PhoneVerificationAdapter {
+  const provider = (process.env.PHONE_VERIFICATION_PROVIDER || 'console').toLowerCase()
+  switch (provider) {
+    case 'twilio':
+      return phoneTwilioAdapter
+    case 'sslwireless':
+      return phoneSSLWirelessAdapter
+    case 'custom':
+      return phoneConsoleAdapter
+    case 'console':
+    default:
+      return phoneConsoleAdapter
+  }
+}
+
+/**
+ * Returns the phone adapter. Use this when provider may be "custom" (async load).
+ * For built-in providers, returns immediately.
+ */
+export async function getPhoneAdapter(): Promise<PhoneVerificationAdapter> {
+  const provider = (process.env.PHONE_VERIFICATION_PROVIDER || 'console').toLowerCase()
+  if (provider !== 'custom') return getPhoneAdapterSync()
+  return loadCustomAdapter()
+}

--- a/packages/backend/src/plugins/verification/adapters/phone-console.ts
+++ b/packages/backend/src/plugins/verification/adapters/phone-console.ts
@@ -1,0 +1,14 @@
+/**
+ * Phase 6.2 — Console-only phone adapter (no SMS sent).
+ * Logs OTP to console when NODE_ENV !== 'production' for testing.
+ */
+import type { PhoneVerificationAdapter } from './phone-types'
+
+export const phoneConsoleAdapter: PhoneVerificationAdapter = {
+  async sendOTP(phone: string, code: string, expirySeconds: number): Promise<boolean> {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[Verification] Phone OTP (console only):', { phone, code, expirySeconds })
+    }
+    return true
+  },
+}

--- a/packages/backend/src/plugins/verification/adapters/phone-sslwireless.ts
+++ b/packages/backend/src/plugins/verification/adapters/phone-sslwireless.ts
@@ -1,0 +1,24 @@
+/**
+ * Phase 6.2 — SSL Wireless SMS adapter (Bangladesh).
+ * Stub: logs OTP when credentials not set. Replace with real API when SSL Wireless credentials are available.
+ * See: https://developer.sslwireless.com/
+ */
+import type { PhoneVerificationAdapter } from './phone-types'
+
+export const phoneSSLWirelessAdapter: PhoneVerificationAdapter = {
+  async sendOTP(phone: string, code: string, expirySeconds: number): Promise<boolean> {
+    const apiKey = process.env.SSLWIRELESS_API_KEY
+    const sender = process.env.SSLWIRELESS_SENDER
+    if (!apiKey || !sender) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('[Verification] SSL Wireless not configured. Phone OTP (console):', { phone, code, expirySeconds })
+      }
+      return true
+    }
+    // TODO: Integrate SSL Wireless SMS API when endpoint/docs are available
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[Verification] SSL Wireless stub — OTP:', { phone, code, expirySeconds })
+    }
+    return true
+  },
+}

--- a/packages/backend/src/plugins/verification/adapters/phone-twilio.ts
+++ b/packages/backend/src/plugins/verification/adapters/phone-twilio.ts
@@ -1,0 +1,54 @@
+/**
+ * Phase 6.2 — Twilio SMS adapter for phone verification.
+ * Sends OTP via Twilio REST API. Requires TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER.
+ */
+import type { PhoneVerificationAdapter } from './phone-types'
+
+function getTwilioConfig(): { accountSid: string; authToken: string; fromNumber: string } | null {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID
+  const authToken = process.env.TWILIO_AUTH_TOKEN
+  const fromNumber = process.env.TWILIO_FROM_NUMBER || process.env.TWILIO_MESSAGING_SERVICE_SID
+  if (!accountSid || !authToken || !fromNumber) return null
+  return { accountSid, authToken, fromNumber }
+}
+
+export const phoneTwilioAdapter: PhoneVerificationAdapter = {
+  async sendOTP(phone: string, code: string, expirySeconds: number): Promise<boolean> {
+    const config = getTwilioConfig()
+    if (!config) {
+      console.warn('[Verification] Twilio not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER). Logging OTP.')
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('[Verification] Phone OTP:', { phone, code, expirySeconds })
+      }
+      return true
+    }
+
+    const body = new URLSearchParams({
+      To: phone.startsWith('+') ? phone : `+${phone}`,
+      From: config.fromNumber,
+      Body: `Your verification code is: ${code}. It expires in ${Math.ceil(expirySeconds / 60)} minutes.`,
+    })
+    const auth = Buffer.from(`${config.accountSid}:${config.authToken}`).toString('base64')
+    const url = `https://api.twilio.com/2010-04-01/Accounts/${config.accountSid}/Messages.json`
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      })
+      if (!res.ok) {
+        const err = await res.text()
+        console.error('[Verification] Twilio error:', res.status, err)
+        return false
+      }
+      return true
+    } catch (err) {
+      console.error('[Verification] Twilio request failed:', err)
+      return false
+    }
+  },
+}

--- a/packages/backend/src/plugins/verification/adapters/phone-types.ts
+++ b/packages/backend/src/plugins/verification/adapters/phone-types.ts
@@ -1,0 +1,7 @@
+/**
+ * Phase 6.2 — Phone verification adapter interface.
+ * Verify is stateless: compare stored code + expiry in the endpoint.
+ */
+export interface PhoneVerificationAdapter {
+  sendOTP(phone: string, code: string, expirySeconds: number): Promise<boolean>
+}

--- a/packages/backend/src/plugins/verification/endpoints/send-verification.ts
+++ b/packages/backend/src/plugins/verification/endpoints/send-verification.ts
@@ -7,12 +7,15 @@
 import type { Endpoint } from 'payload'
 import { sendVerificationLink } from '../adapters/email-link'
 import { sendVerificationOTP } from '../adapters/email-otp'
+import { getPhoneAdapter } from '../adapters/get-phone-adapter'
 import { generateVerificationToken, generateOTP } from '../lib/generate-code'
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const COOLDOWN_MS = 60 * 1000 // 60 seconds
 const DEFAULT_EMAIL_TOKEN_EXPIRY_MINUTES = 30
 const DEFAULT_OTP_EXPIRY_SECONDS = 300
+const DEFAULT_PHONE_OTP_EXPIRY_SECONDS = 300
+const DEFAULT_PHONE_OTP_LENGTH = 6
 
 function getEmailStrategy(): 'link' | 'otp' {
   const v = process.env.EMAIL_VERIFICATION_STRATEGY?.toLowerCase()
@@ -52,18 +55,21 @@ export const sendVerificationEndpoint: Endpoint = {
         return Response.json({ error: 'Invalid email address.' }, { status: 400 })
       }
     }
-    // Phone: accept any non-empty string for now
-
     if (idType === 'phone') {
-      return Response.json(
-        { error: 'Phone verification is not yet implemented (Phase 6.2).' },
-        { status: 501 }
-      )
+      if (trimmed.length < 10) {
+        return Response.json({ error: 'Invalid phone number.' }, { status: 400 })
+      }
     }
 
-    // Optional: require auth and that identifier belongs to user
+    // Optional: if authenticated, identifier must match user's email or phone
     const user = req.user
-    if (user?.email && trimmed.toLowerCase() !== String(user.email).trim().toLowerCase()) {
+    if (idType === 'email' && user?.email && trimmed.toLowerCase() !== String(user.email).trim().toLowerCase()) {
+      return Response.json(
+        { error: 'Identifier does not match the authenticated user.' },
+        { status: 403 }
+      )
+    }
+    if (idType === 'phone' && user?.phone && trimmed !== String(user.phone).trim()) {
       return Response.json(
         { error: 'Identifier does not match the authenticated user.' },
         { status: 403 }
@@ -77,7 +83,7 @@ export const sendVerificationEndpoint: Endpoint = {
       collection: 'verification-codes',
       where: {
         identifier: { equals: trimmed },
-        type: { equals: 'email' },
+        type: { equals: idType },
       },
       limit: 1,
       sort: '-createdAt',
@@ -95,6 +101,35 @@ export const sendVerificationEndpoint: Endpoint = {
       }
     }
 
+    // ─── Phone (Phase 6.2) ───────────────────────────────────────────────────
+    if (idType === 'phone') {
+      const otpLength = Math.min(8, Math.max(4, parseInt(process.env.PHONE_VERIFICATION_OTP_LENGTH || String(DEFAULT_PHONE_OTP_LENGTH), 10) || DEFAULT_PHONE_OTP_LENGTH))
+      const code = generateOTP(otpLength)
+      const expirySeconds = parseInt(process.env.PHONE_VERIFICATION_OTP_EXPIRY || String(DEFAULT_PHONE_OTP_EXPIRY_SECONDS), 10) || DEFAULT_PHONE_OTP_EXPIRY_SECONDS
+      const expiresAt = new Date()
+      expiresAt.setSeconds(expiresAt.getSeconds() + expirySeconds)
+
+      await payload.create({
+        collection: 'verification-codes',
+        data: {
+          identifier: trimmed,
+          type: 'phone',
+          code,
+          expiresAt: expiresAt.toISOString(),
+        },
+        req,
+        overrideAccess: true,
+      })
+
+      const adapter = await getPhoneAdapter()
+      const sent = await adapter.sendOTP(trimmed, code, expirySeconds)
+      if (!sent) {
+        return Response.json({ error: 'Failed to send verification code.' }, { status: 502 })
+      }
+      return Response.json({ success: true, message: 'Verification code sent to your phone.' })
+    }
+
+    // ─── Email ───────────────────────────────────────────────────────────────
     const strategy = getEmailStrategy()
     const expiresAt = new Date()
 

--- a/packages/backend/src/plugins/verification/endpoints/verify-phone.ts
+++ b/packages/backend/src/plugins/verification/endpoints/verify-phone.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/auth/verify-phone
+ * Phase 6.2. Verifies phone using code. On success sets user.phoneVerified = true.
+ */
+import type { Endpoint } from 'payload'
+
+export const verifyPhoneEndpoint: Endpoint = {
+  path: '/auth/verify-phone',
+  method: 'post',
+  handler: async (req) => {
+    const data = (await (req as Request).json?.().catch(() => ({}))) || {}
+    const { code, phone } = data
+
+    if (!code || !phone || typeof code !== 'string' || typeof phone !== 'string') {
+      return Response.json(
+        { error: 'code and phone are required.' },
+        { status: 400 }
+      )
+    }
+
+    const phoneTrimmed = String(phone).trim()
+    const codeTrimmed = code.trim()
+    if (!phoneTrimmed || !codeTrimmed) {
+      return Response.json(
+        { error: 'code and phone are required.' },
+        { status: 400 }
+      )
+    }
+
+    const payload = req.payload
+
+    const { docs } = await payload.find({
+      collection: 'verification-codes',
+      where: {
+        type: { equals: 'phone' },
+        identifier: { equals: phoneTrimmed },
+        code: { equals: codeTrimmed },
+        used: { equals: false },
+      },
+      limit: 1,
+      req,
+      overrideAccess: true,
+    })
+    const record = docs[0]
+    if (!record) {
+      return Response.json(
+        { error: 'Invalid or expired verification code.' },
+        { status: 400 }
+      )
+    }
+    const expiresAt = record.expiresAt ? new Date(record.expiresAt).getTime() : 0
+    if (Date.now() > expiresAt) {
+      return Response.json(
+        { error: 'Verification code has expired. Please request a new one.' },
+        { status: 400 }
+      )
+    }
+
+    await payload.update({
+      collection: 'verification-codes',
+      id: record.id,
+      data: { used: true, usedAt: new Date().toISOString() },
+      req,
+      overrideAccess: true,
+    })
+
+    const { docs: users } = await payload.find({
+      collection: 'users',
+      where: { phone: { equals: phoneTrimmed } },
+      limit: 1,
+    })
+    const user = users[0]
+    if (user) {
+      await payload.update({
+        collection: 'users',
+        id: user.id,
+        data: { phoneVerified: true },
+        req,
+        overrideAccess: true,
+      })
+    }
+
+    return Response.json({ success: true, message: 'Phone verified.' })
+  },
+}

--- a/packages/backend/src/plugins/verification/index.ts
+++ b/packages/backend/src/plugins/verification/index.ts
@@ -1,13 +1,14 @@
 /**
- * Phase 6.1 — Identifier verification plugin.
- * Email: link or OTP strategy (EMAIL_VERIFICATION_STRATEGY=link|otp).
- * Phone: Phase 6.2 (adapters and endpoints TBD).
+ * Phase 6.1/6.2 — Identifier verification plugin.
+ * Email: link or OTP (EMAIL_VERIFICATION_STRATEGY=link|otp).
+ * Phone: OTP via PHONE_VERIFICATION_PROVIDER=twilio|sslwireless|console.
  * See docs/IDENTIFIER-VERIFICATION-BACKLOG.md.
  */
 import type { Plugin } from 'payload'
 import { VerificationCodes } from './collections/verification-codes'
 import { sendVerificationEndpoint } from './endpoints/send-verification'
 import { verifyEmailEndpoint } from './endpoints/verify-email'
+import { verifyPhoneEndpoint } from './endpoints/verify-phone'
 
 export interface VerificationPluginOptions {
   /** Enable the plugin. Default true. */
@@ -27,6 +28,7 @@ export const verificationPlugin =
       ...(incomingConfig.endpoints || []),
       sendVerificationEndpoint,
       verifyEmailEndpoint,
+      verifyPhoneEndpoint,
     ]
 
     return {


### PR DESCRIPTION
## Phase 6.2 — Phone verification + custom adapter

Adds phone OTP verification and a custom phone adapter that can be edited in-repo, with docs and layout suitable for forking and optional complex logic/deps.

### Implemented

**Phone verification**
- `POST /api/auth/send-verification` with `identifierType: 'phone'` — sends OTP via configured adapter (60s cooldown, same as email).
- `POST /api/auth/verify-phone` with `{ code, phone }` — validates code, marks used, sets `user.phoneVerified = true`.
- Adapters: **Twilio** (SMS via REST), **SSL Wireless** (stub), **console** (log only), **custom** (load from path).
- Config: `PHONE_VERIFICATION_PROVIDER=twilio|sslwireless|console|custom`, `PHONE_VERIFICATION_OTP_EXPIRY`, `PHONE_VERIFICATION_OTP_LENGTH`.

**Custom adapter**
- `VERIFICATION_PHONE_ADAPTER_PATH` — path (relative to cwd) to a module that exports `sendOTP(phone, code, expirySeconds) => Promise<boolean>`.
- Loader uses `pathToFileURL()` so dynamic `import()` works on Windows (file:// URL).
- Single in-repo template: `packages/backend/adapters/phone/example-phone-adapter.js` — edit directly; no .example copy step.
- Adapter docs live in-repo: `adapters/phone/README.md` (interface, config, testing, **complex logic and custom dependencies**). No references to platform `docs/` so the BS-Commerce repo is self-contained.

**Layout**
- `adapters/` with one subfolder per type: `adapters/phone/` for phone verification. Ready for future adapter types (e.g. email, notifications).
- README explains: split logic in `adapters/phone/`, add deps to backend `package.json`, or ship adapter as separate npm package and point path to it.

### Files

- **New:** `adapters/phone/example-phone-adapter.js`, `adapters/phone/README.md`, `adapters/README.md`, `endpoints/verify-phone.ts`, phone adapter modules and `get-phone-adapter.ts` (with custom loader + cache).
- **Updated:** `send-verification.ts` (phone flow), plugin `index.ts` (verify-phone endpoint), OpenAPI (verify-phone, send-verification), `.env.example`, `IDENTIFIER-VERIFICATION-BACKLOG.md`, test procedure.
- **Removed:** `example-phone-adapter.example.js` (replaced by single editable file).

### Testing

- Console: `PHONE_VERIFICATION_PROVIDER=console` (default) — OTP in server log.
- Custom: `PHONE_VERIFICATION_PROVIDER=custom`, `VERIFICATION_PHONE_ADAPTER_PATH=./adapters/phone/example-phone-adapter.js` — adapter loads and runs (log-only stub until edited).
- Twilio: set provider and Twilio env vars for real SMS.