### PR TITLE
Coupons: cart-level coupon codes + checkout revalidation

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -185,6 +185,11 @@ PHONE_VERIFICATION_OTP_LENGTH=6
 REQUIRE_VERIFIED_FOR_CHECKOUT=false
 
 # ═══════════════════════════════════════════════════
+# DISCOUNTS & PROMOTIONS (Phase 6)
+# ═══════════════════════════════════════════════════
+DISCOUNTS_ENABLED=true
+
+# ═══════════════════════════════════════════════════
 # ANALYTICS
 # ═══════════════════════════════════════════════════
 ANALYTICS_ENABLED=true

--- a/packages/backend/src/lib/process-checkout.ts
+++ b/packages/backend/src/lib/process-checkout.ts
@@ -12,6 +12,7 @@ import { getDefaultCurrency } from './currencies'
 import { DefaultOrderSplitter, getPlatformItems } from '../plugins/orders/strategies/order-splitter'
 import type { CartItemForSplit } from '../plugins/orders/strategies/order-splitter'
 import { getCommissionRateForTenant, calculateCommission } from './commission'
+import { validateCouponForSubtotal } from '../plugins/discounts/lib/coupon'
 
 /** Creates req with transactionID when adapter supports transactions. */
 function reqWithTransaction(req: PayloadRequest | undefined, transactionID: string | number | null): PayloadRequest {
@@ -178,8 +179,27 @@ export async function processCheckout(
 
   const shippingTotal = 0
   const taxTotal = 0
-  const discountTotal = 0
   const subtotalCalc = orderItemData.reduce((s, i) => s + i.totalPrice, 0)
+  let discountTotal = 0
+  let appliedCouponId: string | null = null
+  let couponCodeSnapshot: string | null = null
+
+  const rawCouponCode = (cart as { couponCode?: string | null }).couponCode
+  if (typeof rawCouponCode === 'string' && rawCouponCode.trim()) {
+    const couponResult = await validateCouponForSubtotal({
+      payload,
+      req,
+      couponCode: rawCouponCode,
+      subtotal: subtotalCalc,
+      userId,
+    })
+    if (!couponResult.valid) {
+      return { order: { id: '', orderNumber: '' }, error: couponResult.discountReason, statusCode: 400 }
+    }
+    appliedCouponId = couponResult.coupon.id
+    couponCodeSnapshot = couponResult.coupon.code
+    discountTotal = couponResult.discountTotal
+  }
   const grandTotal = Math.round((subtotalCalc + shippingTotal + taxTotal - discountTotal) * 100) / 100
 
   const orderNumber = `ORD-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}-${Math.random().toString(36).substring(2, 6).toUpperCase()}`
@@ -202,6 +222,8 @@ export async function processCheckout(
       shippingTotal,
       taxTotal,
       discountTotal,
+      appliedCoupon: appliedCouponId,
+      couponCodeSnapshot,
       grandTotal,
       currency,
       paymentStatus: 'unpaid',
@@ -392,6 +414,24 @@ export async function processCheckout(
       data: orderUpdateData as any,
       req: updateReq,
     })
+
+    if (appliedCouponId) {
+      const couponDoc = await payload.findByID({
+        collection: 'coupons',
+        id: appliedCouponId,
+        depth: 0,
+        overrideAccess: true,
+        req: reqTx,
+      })
+      const currentUses = Number((couponDoc as { totalUses?: number })?.totalUses || 0)
+      await payload.update({
+        collection: 'coupons',
+        id: appliedCouponId,
+        overrideAccess: true,
+        data: { totalUses: currentUses + 1 },
+        req: reqTx,
+      })
+    }
 
     if (simulatePayment) {
       const statusHistoryData: Record<string, unknown> = {

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -24,6 +24,7 @@ import { commissionsPlugin } from './plugins/commissions'
 import { payoutsPlugin } from './plugins/payouts'
 import { notificationsPlugin } from './plugins/notifications'
 import { verificationPlugin } from './plugins/verification'
+import { discountsPlugin } from './plugins/discounts'
 
 import { Header } from './globals/header'
 import { Footer } from './globals/footer'
@@ -238,6 +239,9 @@ export default buildConfig({
     verificationPlugin({
       enabled: process.env.VERIFICATION_ENABLED !== 'false',
       emailStrategy: (process.env.EMAIL_VERIFICATION_STRATEGY as 'link' | 'otp') || 'link',
+    }),
+    discountsPlugin({
+      enabled: process.env.DISCOUNTS_ENABLED !== 'false',
     }),
 
     // Future plugins (added per phase):

--- a/packages/backend/src/plugins/discounts/collections/coupons.ts
+++ b/packages/backend/src/plugins/discounts/collections/coupons.ts
@@ -1,0 +1,56 @@
+import type { CollectionConfig } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+export const Coupons: CollectionConfig = {
+  slug: 'coupons',
+  admin: {
+    useAsTitle: 'code',
+    defaultColumns: ['code', 'type', 'value', 'isActive', 'expiresAt', 'totalUses', 'updatedAt'],
+    group: 'Discounts',
+    description: 'Cart-level coupons. Validation always runs server-side.',
+  },
+  access: {
+    create: isAdmin,
+    read: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  hooks: {
+    beforeValidate: [
+      ({ data }) => {
+        if (!data) return data
+        if (typeof data.code === 'string') {
+          data.code = data.code.trim().toUpperCase()
+        }
+        return data
+      },
+    ],
+  },
+  fields: [
+    { name: 'code', type: 'text', required: true, unique: true, index: true },
+    {
+      name: 'type',
+      type: 'select',
+      required: true,
+      defaultValue: 'percentage',
+      options: [
+        { label: 'Percentage', value: 'percentage' },
+        { label: 'Fixed', value: 'fixed' },
+      ],
+    },
+    { name: 'value', type: 'number', required: true, min: 0 },
+    { name: 'minOrderValue', type: 'number', defaultValue: 0, min: 0 },
+    { name: 'expiresAt', type: 'date' },
+    { name: 'maxTotalUses', type: 'number', min: 1 },
+    { name: 'maxUsesPerUser', type: 'number', min: 1 },
+    { name: 'isActive', type: 'checkbox', defaultValue: true },
+    {
+      name: 'totalUses',
+      type: 'number',
+      defaultValue: 0,
+      min: 0,
+      admin: { readOnly: true, description: 'Auto-incremented after successful checkout.' },
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/discounts/endpoints/coupon-usage.ts
+++ b/packages/backend/src/plugins/discounts/endpoints/coupon-usage.ts
@@ -1,0 +1,76 @@
+import type { Endpoint } from 'payload'
+import { isAdmin } from '../../../access/is-admin'
+
+/**
+ * GET /api/discounts/coupons/:id/usage
+ * Admin-only coupon usage summary endpoint.
+ */
+export const couponUsageEndpoint: Endpoint = {
+  path: '/discounts/coupons/:id/usage',
+  method: 'get',
+  handler: async (req) => {
+    if (!isAdmin({ req } as never)) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const couponId = req.routeParams?.id as string | undefined
+    if (!couponId) {
+      return Response.json({ error: 'Coupon ID is required.' }, { status: 400 })
+    }
+
+    let coupon: any
+    try {
+      coupon = await req.payload.findByID({
+        collection: 'coupons',
+        id: couponId,
+        depth: 0,
+        req,
+        overrideAccess: true,
+      })
+    } catch {
+      return Response.json({ error: 'Coupon not found.' }, { status: 404 })
+    }
+
+    const usageQuery = await req.payload.find({
+      collection: 'orders',
+      where: { appliedCoupon: { equals: couponId } },
+      sort: '-createdAt',
+      limit: 100,
+      depth: 1,
+      req,
+      overrideAccess: true,
+    })
+
+    const totalRedemptions = usageQuery.totalDocs
+    const totalDiscountGiven = usageQuery.docs.reduce((sum, order: any) => {
+      return sum + Number(order.discountTotal || 0)
+    }, 0)
+    const recentOrders = usageQuery.docs.slice(0, 20).map((order: any) => ({
+      id: order.id,
+      orderNumber: order.orderNumber,
+      customer: typeof order.customer === 'object' ? order.customer?.id : order.customer || null,
+      discountTotal: Number(order.discountTotal || 0),
+      grandTotal: Number(order.grandTotal || 0),
+      createdAt: order.createdAt,
+    }))
+
+    return Response.json({
+      coupon: {
+        id: coupon.id,
+        code: coupon.code,
+        type: coupon.type,
+        value: Number(coupon.value || 0),
+        isActive: Boolean(coupon.isActive),
+        totalUses: Number(coupon.totalUses || 0),
+        maxTotalUses: coupon.maxTotalUses ?? null,
+        maxUsesPerUser: coupon.maxUsesPerUser ?? null,
+        expiresAt: coupon.expiresAt ?? null,
+      },
+      usage: {
+        totalRedemptions,
+        totalDiscountGiven: Math.round(totalDiscountGiven * 100) / 100,
+        sampledOrders: recentOrders,
+      },
+    })
+  },
+}

--- a/packages/backend/src/plugins/discounts/index.ts
+++ b/packages/backend/src/plugins/discounts/index.ts
@@ -1,0 +1,20 @@
+import type { Plugin } from 'payload'
+import { Coupons } from './collections/coupons'
+import { couponUsageEndpoint } from './endpoints/coupon-usage'
+
+export interface DiscountsPluginOptions {
+  enabled?: boolean
+}
+
+export const discountsPlugin =
+  (options: DiscountsPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true } = options
+    if (!enabled) return incomingConfig
+
+    return {
+      ...incomingConfig,
+      collections: [...(incomingConfig.collections || []), Coupons],
+      endpoints: [...(incomingConfig.endpoints || []), couponUsageEndpoint],
+    }
+  }

--- a/packages/backend/src/plugins/discounts/lib/coupon.ts
+++ b/packages/backend/src/plugins/discounts/lib/coupon.ts
@@ -1,0 +1,102 @@
+import type { Payload, PayloadRequest } from 'payload'
+
+type CouponDoc = {
+  id: string
+  code: string
+  type: 'percentage' | 'fixed'
+  value: number
+  minOrderValue?: number | null
+  expiresAt?: string | null
+  maxTotalUses?: number | null
+  maxUsesPerUser?: number | null
+  totalUses?: number | null
+  isActive?: boolean
+}
+
+export type CouponValidationResult =
+  | {
+      valid: true
+      coupon: CouponDoc
+      discountTotal: number
+      discountReason?: undefined
+    }
+  | {
+      valid: false
+      coupon?: CouponDoc
+      discountTotal: 0
+      discountReason: string
+    }
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+export async function validateCouponForSubtotal(args: {
+  payload: Payload
+  req?: PayloadRequest
+  couponCode?: string | null
+  subtotal: number
+  userId?: string | number
+}): Promise<CouponValidationResult> {
+  const { payload, couponCode, subtotal, userId } = args
+  const normalizedCode = typeof couponCode === 'string' ? couponCode.trim().toUpperCase() : ''
+  if (!normalizedCode) {
+    return { valid: false, discountTotal: 0, discountReason: 'No coupon code provided' }
+  }
+
+  const found = await payload.find({
+    collection: 'coupons',
+    where: { code: { equals: normalizedCode } },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+    req: args.req,
+  })
+  const coupon = found.docs?.[0] as CouponDoc | undefined
+  if (!coupon) {
+    return { valid: false, discountTotal: 0, discountReason: 'Coupon not found' }
+  }
+  if (coupon.isActive === false) {
+    return { valid: false, discountTotal: 0, coupon, discountReason: 'Coupon is inactive' }
+  }
+  if (coupon.expiresAt && new Date(coupon.expiresAt).getTime() < Date.now()) {
+    return { valid: false, discountTotal: 0, coupon, discountReason: 'Coupon has expired' }
+  }
+
+  const minOrderValue = Number(coupon.minOrderValue || 0)
+  if (subtotal < minOrderValue) {
+    return {
+      valid: false,
+      discountTotal: 0,
+      coupon,
+      discountReason: `Minimum order value is ${minOrderValue}`,
+    }
+  }
+
+  const totalUses = Number(coupon.totalUses || 0)
+  if (coupon.maxTotalUses != null && totalUses >= Number(coupon.maxTotalUses)) {
+    return { valid: false, discountTotal: 0, coupon, discountReason: 'Coupon usage limit reached' }
+  }
+
+  if (coupon.maxUsesPerUser != null && userId != null) {
+    const usedByUser = await payload.find({
+      collection: 'orders',
+      where: {
+        and: [{ customer: { equals: userId } }, { appliedCoupon: { equals: coupon.id } }],
+      },
+      limit: 0,
+      depth: 0,
+      overrideAccess: true,
+      req: args.req,
+    })
+    if (usedByUser.totalDocs >= Number(coupon.maxUsesPerUser)) {
+      return { valid: false, discountTotal: 0, coupon, discountReason: 'Coupon already used by this user' }
+    }
+  }
+
+  const rawDiscount =
+    coupon.type === 'percentage' ? (subtotal * Number(coupon.value || 0)) / 100 : Number(coupon.value || 0)
+  const discountTotal = round2(Math.max(0, Math.min(rawDiscount, subtotal)))
+
+  return { valid: true, coupon, discountTotal }
+}

--- a/packages/backend/src/plugins/ecommerce/collections/carts.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/carts.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig } from 'payload'
+import { APIError, type CollectionConfig } from 'payload'
+import { validateCouponForSubtotal } from '../../discounts/lib/coupon'
 
 const itemFieldsBase = [
   {
@@ -108,6 +109,26 @@ export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig
           0
         )
         data.subtotal = Math.round(subtotal * 100) / 100
+        data.discountTotal = 0
+        data.appliedCoupon = null
+
+        if (typeof data.couponCode === 'string' && data.couponCode.trim()) {
+          const couponResult = await validateCouponForSubtotal({
+            payload: req.payload,
+            req,
+            couponCode: data.couponCode,
+            subtotal: data.subtotal,
+            userId: req.user?.id,
+          })
+          if (!couponResult.valid) {
+            throw new APIError(couponResult.discountReason, 400)
+          }
+          data.couponCode = couponResult.coupon.code
+          data.appliedCoupon = couponResult.coupon.id
+          data.discountTotal = couponResult.discountTotal
+        }
+
+        data.grandTotal = Math.round((Number(data.subtotal || 0) - Number(data.discountTotal || 0)) * 100) / 100
         return data
       },
     ],
@@ -155,6 +176,29 @@ export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig
       type: 'number',
       defaultValue: 0,
       admin: { readOnly: true, description: 'Auto-calculated from items.' },
+    },
+    {
+      name: 'couponCode',
+      type: 'text',
+      admin: { description: 'Optional coupon code. Validated server-side.' },
+    },
+    {
+      name: 'appliedCoupon',
+      type: 'relationship',
+      relationTo: 'coupons',
+      admin: { readOnly: true, description: 'Resolved coupon from couponCode.' },
+    },
+    {
+      name: 'discountTotal',
+      type: 'number',
+      defaultValue: 0,
+      admin: { readOnly: true, description: 'Discount amount from applied coupon.' },
+    },
+    {
+      name: 'grandTotal',
+      type: 'number',
+      defaultValue: 0,
+      admin: { readOnly: true, description: 'subtotal - discountTotal (shipping/tax excluded in cart).' },
     },
     {
       name: 'expiresAt',

--- a/packages/backend/src/plugins/orders/collections/orders.ts
+++ b/packages/backend/src/plugins/orders/collections/orders.ts
@@ -78,6 +78,17 @@ export function createOrdersConfig(splitByVendor: boolean): CollectionConfig {
     { name: 'shippingTotal', type: 'number', required: true, defaultValue: 0 },
     { name: 'taxTotal', type: 'number', required: true, defaultValue: 0 },
     { name: 'discountTotal', type: 'number', required: true, defaultValue: 0 },
+    {
+      name: 'appliedCoupon',
+      type: 'relationship',
+      relationTo: 'coupons',
+      admin: { description: 'Coupon used at checkout (if any).' },
+    },
+    {
+      name: 'couponCodeSnapshot',
+      type: 'text',
+      admin: { readOnly: true, description: 'Coupon code snapshot at checkout time.' },
+    },
     { name: 'grandTotal', type: 'number', required: true, defaultValue: 0 },
     {
       name: 'currency',


### PR DESCRIPTION
## Summary
Implements Phase 6 “Discounts & promotions” coupon foundation with server-side validation and checkout revalidation.

## What’s included
- Admin-manageable `coupons` collection
- Cart-level coupon application:
  - `couponCode` validated server-side in `carts.beforeChange`
  - cart stores `appliedCoupon`, `discountTotal`, and `grandTotal`
  - invalid coupons return proper `400` responses
- Checkout revalidation:
  - `POST /api/checkout/process` re-validates coupon eligibility
  - order persists coupon audit fields: `appliedCoupon`, `couponCodeSnapshot`, `discountTotal`, `grandTotal`
  - increments `coupons.totalUses` only after successful checkout
- Admin coupon analytics endpoint:
  - `GET /api/discounts/coupons/{id}/usage`

## Forward reference / deferred work
Current scope is intentionally limited to cart/order-level coupon discounts.
- No multivendor discount attribution into `sub-orders` yet
- No configurable funding/policy engine (A/B/C) yet
Settlement-policy policy work is documented in:
- `docs/DISCOUNT-COMMISSION-ALLOCATION-RESEARCH.md`
- `docs/DISCOUNTS-PROMOTIONS-CURRENT-IMPLEMENTATION-NOTES.md`

## Docs / API
- Updated `docs/openapi.yaml` (coupon endpoints + cart/order fields + usage endpoint)
- Updated Phase 6 planning docs:
  - `docs/PHASE-6-START.md`
  - `docs/DISCOUNTS-PROMOTIONS-BACKLOG.md`

## Test notes
Use the coupon discount checklist already defined for this Phase 6 “current scope”.
Key checks:
- invalid coupon -> `400` (not `500`)
- valid coupon -> cart discount computed + checkout persists order fields
- expired/inactive/minOrder/maxUses -> rejected at cart update and revalidated at checkout
- `maxTotalUses` enforced at checkout time
- admin usage endpoint returns expected structure