### PR TITLE
Implement reviews plugin with purchase validation and rating aggregation

### DIFF
--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -24,6 +24,7 @@ import { commissionsPlugin } from './plugins/commissions'
 import { payoutsPlugin } from './plugins/payouts'
 import { notificationsPlugin } from './plugins/notifications'
 import { verificationPlugin } from './plugins/verification'
+import { reviewsPlugin } from './plugins/reviews'
 import { discountsPlugin } from './plugins/discounts'
 
 import { Header } from './globals/header'
@@ -242,6 +243,13 @@ export default buildConfig({
     }),
     discountsPlugin({
       enabled: process.env.DISCOUNTS_ENABLED !== 'false',
+    }),
+
+    // Phase 6: Reviews (product + optional vendor reviews)
+    reviewsPlugin({
+      enabled: process.env.REVIEWS_ENABLED !== 'false',
+      requireApproval: process.env.REVIEW_REQUIRES_APPROVAL === 'true',
+      vendorReviews: process.env.MULTIVENDOR_ENABLED === 'true',
     }),
 
     // Future plugins (added per phase):

--- a/packages/backend/src/plugins/ecommerce/collections/products.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/products.ts
@@ -88,6 +88,18 @@ export function createProductsConfig(multivendorEnabled = false): CollectionConf
       ],
     },
     { name: 'publishedAt', type: 'date' },
+    {
+      name: 'rating',
+      type: 'number',
+      defaultValue: 0,
+      admin: { readOnly: true, description: 'Aggregated from approved product reviews.' },
+    },
+    {
+      name: 'totalReviews',
+      type: 'number',
+      defaultValue: 0,
+      admin: { readOnly: true, description: 'Total approved product reviews.' },
+    },
   ]
 
   if (multivendorEnabled) {

--- a/packages/backend/src/plugins/multivendor/collections/vendor-profiles.ts
+++ b/packages/backend/src/plugins/multivendor/collections/vendor-profiles.ts
@@ -77,7 +77,7 @@ export const VendorProfiles: CollectionConfig = {
     {
       name: 'rating',
       type: 'number',
-      admin: { description: 'Aggregated from vendor reviews (Phase 6).', readOnly: true },
+      admin: { description: 'Aggregated from approved vendor reviews.', readOnly: true },
       defaultValue: 0,
     },
     {

--- a/packages/backend/src/plugins/reviews/collections/product-reviews.ts
+++ b/packages/backend/src/plugins/reviews/collections/product-reviews.ts
@@ -1,0 +1,167 @@
+import type { CollectionConfig } from 'payload'
+import { APIError } from 'payload'
+
+import { userPurchasedProduct } from '../lib/purchase-checks'
+import { recomputeProductRating } from '../lib/aggregate-ratings'
+
+const ReviewStatus = {
+  Pending: 'pending',
+  Approved: 'approved',
+  Rejected: 'rejected',
+} as const
+type ReviewStatus = (typeof ReviewStatus)[keyof typeof ReviewStatus]
+
+function toStringId(value: unknown): string {
+  if (value == null) return ''
+  return typeof value === 'string' ? value : String(value)
+}
+
+function relationId(value: unknown): string {
+  if (value == null) return ''
+  if (typeof value === 'object') return toStringId((value as any).id)
+  return toStringId(value)
+}
+
+export function createProductReviewsConfig(args: { requireApproval: boolean }): CollectionConfig {
+  const { requireApproval } = args
+
+  return {
+    slug: 'product-reviews',
+    admin: {
+      useAsTitle: 'id',
+      defaultColumns: ['product', 'author', 'rating', 'status', 'createdAt'],
+      group: 'Reviews',
+      description: 'Customer product reviews. Public read (approved only if moderation enabled).',
+    },
+    access: {
+      create: ({ req }) => req.user?.role === 'customer',
+      read: ({ req }) => {
+        if (req.user?.role === 'admin') return true
+        if (requireApproval) return { status: { equals: ReviewStatus.Approved } }
+        return true
+      },
+      update: ({ req }) => {
+        if (!req.user) return false
+        if (req.user.role === 'admin') return true
+        // Hook will enforce "own only" on update.
+        return req.user.role === 'customer'
+      },
+      delete: ({ req }) => req.user?.role === 'admin',
+    },
+    fields: [
+      {
+        name: 'product',
+        type: 'relationship',
+        relationTo: 'products',
+        required: true,
+        admin: { description: 'Reviewed product.' },
+      },
+      {
+        name: 'author',
+        type: 'relationship',
+        relationTo: 'users',
+        required: true,
+        admin: { description: 'Review author (customer).' },
+      },
+      { name: 'rating', type: 'number', required: true, min: 1, max: 5, admin: { step: 1 } },
+      { name: 'title', type: 'text', required: false },
+      { name: 'comment', type: 'textarea', localized: true },
+      {
+        name: 'status',
+        type: 'select',
+        required: true,
+        defaultValue: requireApproval ? ReviewStatus.Pending : ReviewStatus.Approved,
+        options: [
+          { label: 'Pending', value: ReviewStatus.Pending },
+          { label: 'Approved', value: ReviewStatus.Approved },
+          { label: 'Rejected', value: ReviewStatus.Rejected },
+        ],
+      },
+    ],
+    hooks: {
+      beforeChange: [
+        async ({ data, operation, req, originalDoc }) => {
+          if (!req.user) throw new APIError('Forbidden', 403)
+
+          const userId = String(req.user.id)
+
+          if (operation === 'create') {
+            if (req.user.role !== 'customer') throw new APIError('Forbidden', 403)
+
+            const productId = relationId(data.product)
+
+            if (!productId) throw new APIError('product is required', 400)
+
+            const canReview = await userPurchasedProduct({
+              payload: req.payload,
+              userId,
+              productId,
+              req,
+            })
+            if (!canReview) {
+              throw new APIError('You can only review products you have purchased.', 400)
+            }
+
+            // One review per user per product (enforced at hook level).
+            const existing = await req.payload.find({
+              collection: 'product-reviews',
+              where: {
+                product: { equals: productId },
+                author: { equals: userId },
+              },
+              limit: 1,
+              depth: 0,
+              req,
+              overrideAccess: true,
+            })
+
+            if (existing.totalDocs > 0) {
+              throw new APIError('You already reviewed this product.', 400)
+            }
+
+            data.author = userId
+            data.status = requireApproval ? ReviewStatus.Pending : ReviewStatus.Approved
+            return data
+          }
+
+          // Update: enforce only owner can update, and only admin can change status.
+          if (operation === 'update') {
+            const prev = originalDoc as any
+            const prevAuthor = relationId(prev?.author)
+            const incomingAuthor = relationId(data.author)
+            if (req.user.role !== 'admin') {
+              if (prevAuthor && prevAuthor !== userId) throw new APIError('Forbidden', 403)
+              if (incomingAuthor && prevAuthor && incomingAuthor !== prevAuthor) {
+                throw new APIError('Forbidden: author cannot be changed.', 403)
+              }
+              if (data.status != null && data.status !== prev.status) {
+                throw new APIError('Forbidden: only admin can change review status.', 403)
+              }
+            }
+
+            // Keep author stable for non-admin updates.
+            if (req.user.role !== 'admin' && prevAuthor) {
+              data.author = prevAuthor
+            }
+          }
+
+          return data
+        },
+      ],
+      afterChange: [
+        async ({ doc, req }) => {
+          if (!doc) return doc
+
+          const productId = relationId((doc as any).product)
+          if (!productId) return doc
+
+          // Always recompute on any create/update so approved->rejected (or reverse) is reflected.
+          await recomputeProductRating(req.payload, { productId, req })
+          return doc
+        },
+      ],
+    },
+    timestamps: true,
+  }
+}
+

--- a/packages/backend/src/plugins/reviews/collections/vendor-reviews.ts
+++ b/packages/backend/src/plugins/reviews/collections/vendor-reviews.ts
@@ -1,0 +1,175 @@
+import type { CollectionConfig } from 'payload'
+import { APIError } from 'payload'
+
+import { userPurchasedTenant } from '../lib/purchase-checks'
+import { recomputeVendorRating } from '../lib/aggregate-ratings'
+
+const ReviewStatus = {
+  Pending: 'pending',
+  Approved: 'approved',
+  Rejected: 'rejected',
+} as const
+type ReviewStatus = (typeof ReviewStatus)[keyof typeof ReviewStatus]
+
+function toStringId(value: unknown): string {
+  if (value == null) return ''
+  return typeof value === 'string' ? value : String(value)
+}
+
+function relationId(value: unknown): string {
+  if (value == null) return ''
+  if (typeof value === 'object') return toStringId((value as any).id)
+  return toStringId(value)
+}
+
+export function createVendorReviewsConfig(args: { requireApproval: boolean }): CollectionConfig {
+  const { requireApproval } = args
+
+  return {
+    slug: 'vendor-reviews',
+    admin: {
+      useAsTitle: 'id',
+      defaultColumns: ['tenant', 'author', 'rating', 'status', 'createdAt'],
+      group: 'Reviews',
+      description: 'Customer vendor reviews (multivendor). Public read (approved only if moderation enabled).',
+    },
+    access: {
+      create: ({ req }) => req.user?.role === 'customer',
+      read: ({ req }) => {
+        if (req.user?.role === 'admin') return true
+
+        const statusApproved = { status: { equals: ReviewStatus.Approved } }
+
+        if (req.user?.role === 'vendor' && req.user.tenant) {
+          const tenantId = relationId(req.user.tenant)
+          return tenantId ? ({ tenant: { equals: tenantId } } as any) : false
+        }
+
+        if (req.user?.role === 'customer') {
+          if (!requireApproval) return true
+          // Customers can always read their own reviews (even pending), otherwise only approved reviews.
+          return {
+            or: [statusApproved, { author: { equals: String(req.user.id) } }],
+          } as any
+        }
+
+        // Guest/customer: requireApproval => approved only.
+        return requireApproval ? (statusApproved as any) : true
+      },
+      update: ({ req }) => {
+        if (!req.user) return false
+        if (req.user.role === 'admin') return true
+        // Hook will enforce "own only" and forbid status changes for non-admins.
+        return req.user.role === 'customer'
+      },
+      delete: ({ req }) => req.user?.role === 'admin',
+    },
+    fields: [
+      {
+        name: 'tenant',
+        type: 'relationship',
+        relationTo: 'tenants',
+        required: true,
+        admin: { description: 'Vendor (tenant) being reviewed.' },
+      },
+      {
+        name: 'author',
+        type: 'relationship',
+        relationTo: 'users',
+        required: true,
+        admin: { description: 'Review author (customer).' },
+      },
+      { name: 'rating', type: 'number', required: true, min: 1, max: 5, admin: { step: 1 } },
+      { name: 'title', type: 'text', required: false },
+      { name: 'comment', type: 'textarea', localized: true },
+      {
+        name: 'status',
+        type: 'select',
+        required: true,
+        defaultValue: requireApproval ? ReviewStatus.Pending : ReviewStatus.Approved,
+        options: [
+          { label: 'Pending', value: ReviewStatus.Pending },
+          { label: 'Approved', value: ReviewStatus.Approved },
+          { label: 'Rejected', value: ReviewStatus.Rejected },
+        ],
+      },
+    ],
+    hooks: {
+      beforeChange: [
+        async ({ data, operation, req, originalDoc }) => {
+          if (!req.user) throw new APIError('Forbidden', 403)
+
+          const userId = String(req.user.id)
+
+          if (operation === 'create') {
+            if (req.user.role !== 'customer') throw new APIError('Forbidden', 403)
+
+            const tenantId = relationId(data.tenant)
+            if (!tenantId) throw new APIError('tenant is required', 400)
+
+            const canReview = await userPurchasedTenant({
+              payload: req.payload,
+              userId,
+              tenantId,
+              req,
+            })
+            if (!canReview) throw new APIError('You can only review vendors you have purchased from.', 400)
+
+            const existing = await req.payload.find({
+              collection: 'vendor-reviews',
+              where: { tenant: { equals: tenantId }, author: { equals: userId } },
+              limit: 1,
+              depth: 0,
+              req,
+              overrideAccess: true,
+            })
+
+            if (existing.totalDocs > 0) throw new APIError('You already reviewed this vendor.', 400)
+
+            data.author = userId
+            data.status = requireApproval ? ReviewStatus.Pending : ReviewStatus.Approved
+            return data
+          }
+
+          // Update: enforce owner can edit content; only admin can change status.
+          if (operation === 'update') {
+            const prev = (originalDoc as any) ?? {}
+            const prevAuthor = relationId(prev.author)
+            const incomingAuthor = relationId(data.author)
+
+            if (req.user.role !== 'admin') {
+              if (prevAuthor && prevAuthor !== userId) throw new APIError('Forbidden', 403)
+              if (incomingAuthor && prevAuthor && incomingAuthor !== prevAuthor) {
+                throw new APIError('Forbidden: author cannot be changed.', 403)
+              }
+              if (data.status != null && data.status !== prev.status) {
+                throw new APIError('Forbidden: only admin can change review status.', 403)
+              }
+            }
+
+            // Keep author stable for non-admin updates.
+            if (req.user.role !== 'admin' && prevAuthor) {
+              data.author = prevAuthor
+            }
+          }
+
+          return data
+        },
+      ],
+      afterChange: [
+        async ({ doc, req }) => {
+          if (!doc) return doc
+
+          const tenantId = relationId((doc as any).tenant)
+          if (!tenantId) return doc
+
+          // Always recompute on any create/update so approved->rejected (or reverse) is reflected.
+          await recomputeVendorRating(req.payload, { tenantId, req })
+          return doc
+        },
+      ],
+    },
+    timestamps: true,
+  }
+}
+

--- a/packages/backend/src/plugins/reviews/index.ts
+++ b/packages/backend/src/plugins/reviews/index.ts
@@ -1,0 +1,35 @@
+import type { Plugin } from 'payload'
+import { createProductReviewsConfig } from './collections/product-reviews'
+import { createVendorReviewsConfig } from './collections/vendor-reviews'
+
+export interface ReviewsPluginOptions {
+  enabled?: boolean
+  /** When true, new customer reviews start in pending state and require admin approval. */
+  requireApproval?: boolean
+  /** When true, register vendor reviews (multivendor mode). */
+  vendorReviews?: boolean
+}
+
+/**
+ * Reviews plugin
+ * - Product reviews (customer-authored, public read)
+ * - Optional vendor reviews in multivendor mode
+ * - Rating aggregation into products.vendor-profiles (admin readOnly fields updated by hooks)
+ */
+export const reviewsPlugin =
+  (options: ReviewsPluginOptions = {}): Plugin =>
+  (incomingConfig) => {
+    const { enabled = true, requireApproval = false, vendorReviews = false } = options
+    if (!enabled) return incomingConfig
+
+    const collections = [
+      createProductReviewsConfig({ requireApproval }),
+      ...(vendorReviews ? [createVendorReviewsConfig({ requireApproval })] : []),
+    ]
+
+    return {
+      ...incomingConfig,
+      collections: [...(incomingConfig.collections || []), ...collections],
+    }
+  }
+

--- a/packages/backend/src/plugins/reviews/lib/aggregate-ratings.ts
+++ b/packages/backend/src/plugins/reviews/lib/aggregate-ratings.ts
@@ -1,0 +1,71 @@
+import type { Payload } from 'payload'
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+export async function recomputeProductRating(payload: Payload, args: { productId: string; req?: any }): Promise<void> {
+  const { productId, req } = args
+
+  const { docs } = await payload.find({
+    collection: 'product-reviews',
+    where: { product: { equals: productId }, status: { equals: 'approved' } },
+    limit: 5000,
+    depth: 0,
+    req,
+    overrideAccess: true,
+  })
+
+  const ratings = (docs as any[]).map((d) => Number(d.rating) || 0)
+  const count = ratings.length
+  const avg = count ? ratings.reduce((s, r) => s + r, 0) / count : 0
+
+  await payload.update({
+    collection: 'products',
+    id: productId,
+    overrideAccess: true,
+    data: {
+      rating: round2(avg),
+      totalReviews: count,
+    },
+    req,
+  })
+}
+
+export async function recomputeVendorRating(payload: Payload, args: { tenantId: string; req?: any }): Promise<void> {
+  const { tenantId, req } = args
+
+  const { docs } = await payload.find({
+    collection: 'vendor-reviews',
+    where: { tenant: { equals: tenantId }, status: { equals: 'approved' } },
+    limit: 5000,
+    depth: 0,
+    req,
+    overrideAccess: true,
+  })
+
+  const ratings = (docs as any[]).map((d) => Number(d.rating) || 0)
+  const count = ratings.length
+  const avg = count ? ratings.reduce((s, r) => s + r, 0) / count : 0
+
+  const { docs: profiles } = await payload.find({
+    collection: 'vendor-profiles',
+    where: { tenant: { equals: tenantId } },
+    limit: 1,
+    depth: 0,
+    req,
+    overrideAccess: true,
+  })
+
+  const profile = profiles[0]
+  if (!profile) return
+
+  await payload.update({
+    collection: 'vendor-profiles',
+    id: profile.id,
+    overrideAccess: true,
+    data: { rating: round2(avg) },
+    req,
+  })
+}
+

--- a/packages/backend/src/plugins/reviews/lib/purchase-checks.ts
+++ b/packages/backend/src/plugins/reviews/lib/purchase-checks.ts
@@ -1,0 +1,167 @@
+import type { Payload } from 'payload'
+
+/**
+ * Reviews should only be allowed after the relevant fulfillment happened:
+ * - Product reviews: only if the specific product's items are part of a shipped/delivered/completed segment.
+ * - Vendor reviews: only if the customer has at least one shipped/delivered/completed sub-order for that tenant.
+ *
+ * Important: In multivendor mode, the parent order status can be `partially-shipped` even when a specific vendor's items
+ * are still pending. So we validate using sub-order status for tenant-owned products.
+ */
+const RELEVANT_SUBORDER_STATUSES = ['shipped', 'delivered', 'completed'] as const
+type RelevantSuborderStatus = (typeof RELEVANT_SUBORDER_STATUSES)[number]
+
+const RELEVANT_PARENT_ORDER_STATUSES_SINGLE_VS_PLATFORM = ['shipped', 'delivered', 'completed'] as const
+type RelevantParentOrderStatus = (typeof RELEVANT_PARENT_ORDER_STATUSES_SINGLE_VS_PLATFORM)[number]
+
+const RELEVANT_PARENT_ORDER_STATUSES_VENDOR = ['partially-shipped', 'shipped', 'delivered', 'completed'] as const
+type RelevantParentOrderStatusVendor = (typeof RELEVANT_PARENT_ORDER_STATUSES_VENDOR)[number]
+
+function toStringId(value: unknown): string {
+  if (value == null) return ''
+  return typeof value === 'string' ? value : String(value)
+}
+
+async function getProductTenantId(payload: Payload, productId: string, req?: any): Promise<string> {
+  const product = await payload.findByID({
+    collection: 'products',
+    id: productId,
+    depth: 0,
+    overrideAccess: true,
+    ...(req ? { req } : {}),
+  })
+
+  const tenant = (product as any)?.tenant
+  const tenantId = tenant && typeof tenant === 'object' ? (tenant as any).id : tenant
+  return toStringId(tenantId)
+}
+
+export async function userPurchasedProduct(args: {
+  payload: Payload
+  userId: string
+  productId: string
+  req?: any
+}): Promise<boolean> {
+  const { payload, userId, productId, req } = args
+
+  const tenantId = await getProductTenantId(payload, productId, req)
+
+  // Multivendor: if product is tenant-owned, use sub-order fulfillment validation.
+  if (process.env.MULTIVENDOR_ENABLED === 'true' && tenantId) {
+    // 1) Parent orders for this customer.
+    const customerOrders = await payload.find({
+      collection: 'orders',
+      where: { customer: { equals: userId } },
+      limit: 5000,
+      depth: 0,
+      req,
+      overrideAccess: true,
+    })
+
+    const parentOrderIds = customerOrders.docs.map((o: any) => String(o.id)).filter(Boolean)
+    if (!parentOrderIds.length) return false
+
+    // 2) Sub-orders that are fulfilled for this tenant AND belong to those parent orders.
+    const fulfilledSubOrders = await payload.find({
+      collection: 'sub-orders',
+      where: {
+        tenant: { equals: tenantId },
+        status: { in: RELEVANT_SUBORDER_STATUSES as unknown as RelevantSuborderStatus[] },
+        parentOrder: { in: parentOrderIds },
+      },
+      limit: 5000,
+      depth: 0,
+      req,
+      overrideAccess: true,
+    })
+
+    const fulfilledSubOrderIds = fulfilledSubOrders.docs.map((d: any) => String(d.id)).filter(Boolean)
+    if (!fulfilledSubOrderIds.length) return false
+
+    // 3) Confirm this product exists inside at least one fulfilled sub-order.
+    const orderItemResult = await payload.find({
+      collection: 'order-items',
+      where: {
+        product: { equals: productId },
+        subOrder: { in: fulfilledSubOrderIds },
+      },
+      limit: 1,
+      depth: 0,
+      req,
+      overrideAccess: true,
+    })
+
+    return orderItemResult.totalDocs > 0
+  }
+
+  // Single-vendor or platform-owned product: validate using parent order fulfillment.
+  const fulfilledOrders = await payload.find({
+    collection: 'orders',
+    where: {
+      customer: { equals: userId },
+      status: { in: RELEVANT_PARENT_ORDER_STATUSES_SINGLE_VS_PLATFORM as unknown as RelevantParentOrderStatus[] },
+    },
+    limit: 5000,
+    depth: 0,
+    req,
+    overrideAccess: true,
+  })
+
+  const orderIds = fulfilledOrders.docs.map((o: any) => String(o.id)).filter(Boolean)
+  if (!orderIds.length) return false
+
+  const orderItemResult = await payload.find({
+    collection: 'order-items',
+    where: {
+      order: { in: orderIds },
+      product: { equals: productId },
+    },
+    limit: 1,
+    depth: 0,
+    req,
+    overrideAccess: true,
+  })
+
+  return orderItemResult.totalDocs > 0
+}
+
+export async function userPurchasedTenant(args: {
+  payload: Payload
+  userId: string
+  tenantId: string
+  req?: any
+}): Promise<boolean> {
+  const { payload, userId, tenantId, req } = args
+
+  // For vendor reviews, validate using fulfilled sub-orders for the tenant.
+  const customerOrders = await payload.find({
+    collection: 'orders',
+    where: {
+      customer: { equals: userId },
+      status: { in: RELEVANT_PARENT_ORDER_STATUSES_VENDOR as unknown as RelevantParentOrderStatusVendor[] },
+    },
+    limit: 5000,
+    depth: 0,
+    req,
+    overrideAccess: true,
+  })
+
+  const parentOrderIds = customerOrders.docs.map((o: any) => String(o.id)).filter(Boolean)
+  if (!parentOrderIds.length) return false
+
+  const fulfilledSubOrders = await payload.find({
+    collection: 'sub-orders',
+    where: {
+      tenant: { equals: tenantId },
+      status: { in: RELEVANT_SUBORDER_STATUSES as unknown as RelevantSuborderStatus[] },
+      parentOrder: { in: parentOrderIds },
+    },
+    limit: 5000,
+    depth: 0,
+    req,
+    overrideAccess: true,
+  })
+
+  return fulfilledSubOrders.totalDocs > 0
+}
+


### PR DESCRIPTION
## Summary
Implements the Phase 6 Reviews backend feature with product/vendor reviews, purchase-based eligibility checks, moderation support, and rating aggregation.

## Scope implemented

### 1) Reviews plugin registration
- Added and registered `reviewsPlugin` in Payload config.
- Feature flags:
  - `REVIEWS_ENABLED` (enable/disable plugin)
  - `REVIEW_REQUIRES_APPROVAL` (moderation on/off)
- Vendor review registration is tied to multivendor mode:
  - `vendorReviews: process.env.MULTIVENDOR_ENABLED === 'true'`

### 2) Product reviews
- New collection: `product-reviews`
- Customer can create/update own review.
- Admin can read/update/delete all.
- Public read:
  - moderation OFF: all reviews readable
  - moderation ON: approved-only for public
- Enforces one review per user per product.
- Purchase validation required before create.

### 3) Vendor reviews (multivendor)
- New collection: `vendor-reviews`
- Customer can create/update own vendor review.
- Admin can read/update/delete all.
- Vendor can read reviews for own tenant.
- Public read with moderation behavior similar to product reviews.
- Enforces one review per user per tenant.
- Purchase-from-tenant validation required before create.

### 4) Eligibility validation logic
- Added purchase checks in reviews lib.
- Validation is fulfillment-aware:
  - In multivendor flows, checks relevant `sub-orders` fulfillment status (`shipped|delivered|completed`) for tenant-owned products/vendors.
  - Avoids relying only on parent order `partially-shipped` where unrelated items could cause false eligibility.

### 5) Rating aggregation
- Added aggregation logic:
  - Product aggregates:
    - `products.rating`
    - `products.totalReviews`
  - Vendor aggregate:
    - `vendor-profiles.rating`
- Aggregation recalculates from approved reviews only.
- Recompute runs on review create/update so moderation transitions are reflected.

### 6) Regression fix included
- Fixed aggregate consistency issue:
  - When an approved review is changed to rejected/non-approved, aggregate values now recalculate immediately and exclude that review.

## Notes
- This PR focuses on backend foundation only.
- Advanced review features (helpful votes, media attachments, anti-spam scoring, richer moderation workflow) are intentionally out of scope.
- OpenAPI/docs were handled separately based on branch/doc workflow preferences.

## Test checklist (high-level)
- Product review create requires fulfilled purchase.
- Vendor review create requires fulfilled purchase-from-tenant.
- Duplicate reviews blocked (same user + same product/tenant).
- Moderation ON:
  - newly created reviews default to pending
  - public read excludes non-approved
- Moderation transition:
  - approved -> rejected updates aggregates correctly.
- Product/vendor rating fields reflect approved reviews only.