### PR TITLE
Phase 6: harden guest checkout security and add automated abuse-focused backend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ See `packages/backend/.env.example` for the full list.
 | `REDIS_URL` | Redis URL — required |
 | `PAYLOAD_SECRET` | Auth token secret |
 | `MULTIVENDOR_ENABLED` | `true` = marketplace, `false` = single-vendor |
+| `GUEST_CHECKOUT_ENABLED` | Enables guest cart + guest checkout flow |
+| `CHECKOUT_RATE_LIMIT_POINTS` | Max checkout requests per rate-limit window |
+| `CHECKOUT_RATE_LIMIT_DURATION_SECONDS` | Checkout rate-limit window in seconds |
+| `GUEST_LOOKUP_RATE_LIMIT_POINTS` | Max guest order-lookup requests per window |
+| `GUEST_LOOKUP_RATE_LIMIT_DURATION_SECONDS` | Guest lookup rate-limit window in seconds |
 
 ## Modes
 
@@ -56,6 +61,20 @@ See `packages/backend/.env.example` for the full list.
 |------|---------|
 | Single-vendor | `MULTIVENDOR_ENABLED=false` |
 | Marketplace | `MULTIVENDOR_ENABLED=true` |
+
+## Guest Checkout Testing
+
+From `packages/backend`, run:
+
+```bash
+yarn test:guest
+```
+
+Optional flags:
+
+- `RUN_RATE_LIMIT=true` to include rate-limit assertions
+- `PRODUCT_ID=<id>` to pin a specific product (otherwise the first published product is used)
+- `AUTH_TOKEN=<jwt>` to run authenticated abuse checks when login policy blocks auto-created test users
 
 ## License
 

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -21,6 +21,12 @@ DATABASE_ID_TYPE=uuid
 # Decision #16: Required for query caching + rate limiting
 # ═══════════════════════════════════════════════════
 REDIS_URL=redis://localhost:6379
+# Checkout endpoint rate limit (per IP): default 5 requests / 60 seconds
+CHECKOUT_RATE_LIMIT_POINTS=5
+CHECKOUT_RATE_LIMIT_DURATION_SECONDS=60
+# Guest order lookup rate limit (per IP): default 10 requests / 900 seconds (15 min)
+GUEST_LOOKUP_RATE_LIMIT_POINTS=10
+GUEST_LOOKUP_RATE_LIMIT_DURATION_SECONDS=900
 
 # ═══════════════════════════════════════════════════
 # APPLICATION
@@ -60,6 +66,8 @@ PRODUCT_REQUIRES_APPROVAL=false
 # ═══════════════════════════════════════════════════
 SUPPORTED_CURRENCIES=USD,BDT
 DEFAULT_CURRENCY=USD
+# Controls guest cart CRUD (via X-Guest-Id header) and guest checkout.
+# When false, only authenticated users can create/manage carts and check out.
 GUEST_CHECKOUT_ENABLED=true
 
 # ═══════════════════════════════════════════════════

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test:guest": "node scripts/test-guest-checkout.mjs",
     "generate:types": "payload generate:types",
     "generate:importmap": "payload generate:importMap",
     "payload": "payload"
@@ -27,6 +28,7 @@
     "next": "15.4.11",
     "payload": "^3.77.0",
     "payloadcms-redis-plugin": "^0.2.17",
+    "rate-limiter-flexible": "^10.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sharp": "^0.32.6"

--- a/packages/backend/scripts/test-guest-checkout.mjs
+++ b/packages/backend/scripts/test-guest-checkout.mjs
@@ -1,0 +1,557 @@
+#!/usr/bin/env node
+/**
+ * Guest checkout E2E (backend API). Fully automated: picks the first published
+ * product from GET /api/products unless PRODUCT_ID is set.
+ *
+ * Usage (from packages/backend): yarn test:guest
+ * Optional: PRODUCT_ID=... RUN_RATE_LIMIT=true VERBOSE=true BASE_URL=...
+ */
+
+import crypto from 'node:crypto'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000'
+const API_BASE = `${BASE_URL.replace(/\/$/, '')}/api`
+const RUN_RATE_LIMIT = process.env.RUN_RATE_LIMIT === 'true'
+const VERBOSE = process.env.VERBOSE === 'true'
+const AUTH_TOKEN = process.env.AUTH_TOKEN || null
+
+const state = {
+  guestId: crypto.randomUUID(),
+  otherGuestId: crypto.randomUUID(),
+  productId: null,
+  orderNumber: null,
+  orderId: null,
+  authToken: null,
+  authUserEmail: null,
+}
+const ipSegment = (crypto.randomInt(1, 250)).toString()
+function ip(host) {
+  return `10.10.${ipSegment}.${host}`
+}
+
+const summary = []
+
+function logStep(name) {
+  console.log(`\n[STEP] ${name}`)
+}
+
+function pass(name, detail = '') {
+  summary.push({ name, ok: true, detail })
+  console.log(`  PASS ${name}${detail ? ` - ${detail}` : ''}`)
+}
+
+function fail(name, detail = '') {
+  summary.push({ name, ok: false, detail })
+  console.error(`  FAIL ${name}${detail ? ` - ${detail}` : ''}`)
+}
+
+function skip(name, detail = '') {
+  summary.push({ name, ok: true, skipped: true, detail })
+  console.log(`  SKIP ${name}${detail ? ` - ${detail}` : ''}`)
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+async function request(path, { method = 'GET', headers = {}, body } = {}) {
+  const reqHeaders = { ...headers }
+  let reqBody
+  if (body !== undefined) {
+    reqHeaders['Content-Type'] = reqHeaders['Content-Type'] || 'application/json'
+    reqBody = typeof body === 'string' ? body : JSON.stringify(body)
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: reqHeaders,
+    body: reqBody,
+  })
+
+  const text = await res.text()
+  let json = null
+  try {
+    json = text ? JSON.parse(text) : null
+  } catch {
+    json = null
+  }
+
+  if (VERBOSE) {
+    console.log(`    ${method} ${path} -> ${res.status}`)
+    if (text) console.log(`    body: ${text.slice(0, 500)}`)
+  }
+
+  return { res, status: res.status, json, text, headers: res.headers }
+}
+
+async function registerAndLoginCustomer() {
+  const email = `pentest-${Date.now()}-${crypto.randomInt(1000, 9999)}@example.com`
+  const password = 'Test1234!Secure'
+
+  const created = await request('/users', {
+    method: 'POST',
+    body: {
+      email,
+      password,
+      firstName: 'Pentest',
+      lastName: 'User',
+    },
+  })
+  if (![200, 201].includes(created.status)) {
+    throw new Error(`Failed to create test user (${created.status}): ${created.text}`)
+  }
+
+  const login = await request('/auth/login', {
+    method: 'POST',
+    body: { identifier: email, password },
+  })
+  if (login.status !== 200 || !login.json?.token) {
+    throw new Error(`Failed to login test user (${login.status}): ${login.text}`)
+  }
+
+  return { email, token: login.json.token }
+}
+
+function getDoc(payload) {
+  if (!payload || typeof payload !== 'object') return null
+  return payload.doc || payload.docs?.[0] || payload
+}
+
+/**
+ * Uses PRODUCT_ID env if set; otherwise lists published products (public read).
+ */
+async function resolveProductId() {
+  const explicit = process.env.PRODUCT_ID?.trim()
+  if (explicit) return explicit
+
+  const qs = new URLSearchParams()
+  qs.set('limit', '25')
+  qs.set('depth', '0')
+  qs.set('where[status][equals]', 'published')
+
+  let r
+  try {
+    r = await request(`/products?${qs.toString()}`)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(
+      `Could not reach ${BASE_URL} (list products failed: ${msg}). Start the backend: yarn dev`,
+    )
+  }
+  if (r.status !== 200) {
+    throw new Error(
+      `Failed to list products (${r.status}). Is the backend running at ${BASE_URL}? ${r.text?.slice(0, 200) ?? ''}`,
+    )
+  }
+  const docs = r.json?.docs ?? []
+  if (!docs.length) {
+    throw new Error(
+      'No published products found. Publish at least one product in Admin, or set PRODUCT_ID to a product id.',
+    )
+  }
+  const id = docs[0]?.id
+  if (id == null) throw new Error('Product list returned a doc without id')
+  return String(id)
+}
+
+async function createCart(guestId, quantity = 1) {
+  const result = await request('/carts', {
+    method: 'POST',
+    headers: { 'X-Guest-Id': guestId },
+    body: {
+      items: [{ product: state.productId, quantity }],
+    },
+  })
+
+  if (result.status !== 201) return { ...result, cartId: null }
+  const doc = getDoc(result.json)
+  const cartId = doc?.id
+  return { ...result, cartId }
+}
+
+async function checkoutAsGuest({ cartId, guestId, guestEmail, idempotencyKey, simulatePayment = true, forwardedFor }) {
+  const headers = { 'X-Guest-Id': guestId }
+  if (forwardedFor) headers['x-forwarded-for'] = forwardedFor
+  const result = await request('/checkout/process', {
+    method: 'POST',
+    headers,
+    body: {
+      cartId,
+      guestEmail,
+      idempotencyKey,
+      simulatePayment,
+      shippingAddress: {
+        firstName: 'Test',
+        lastName: 'Guest',
+        street1: '1 Main St',
+        city: 'Dhaka',
+        country: 'BD',
+      },
+      billingAddress: {
+        firstName: 'Test',
+        lastName: 'Guest',
+        street1: '1 Main St',
+        city: 'Dhaka',
+        country: 'BD',
+      },
+    },
+  })
+
+  return result
+}
+
+async function testCartLifecycle() {
+  logStep('B: Guest cart lifecycle')
+
+  const created = await createCart(state.guestId, 2)
+  assert(created.status === 201, `Expected 201 creating cart, got ${created.status}`)
+  assert(created.cartId, 'Cart ID missing from create response')
+  const cartId = created.cartId
+  pass('B1 create cart', `cartId=${cartId}`)
+
+  const ownRead = await request(`/carts/${cartId}`, {
+    headers: { 'X-Guest-Id': state.guestId },
+  })
+  assert(ownRead.status === 200, `Expected 200 reading own cart, got ${ownRead.status}`)
+  pass('B2 read own cart')
+
+  const wrongRead = await request(`/carts/${cartId}`, {
+    headers: { 'X-Guest-Id': state.otherGuestId },
+  })
+  assert([403, 404].includes(wrongRead.status), `Expected 403/404 reading with wrong guest, got ${wrongRead.status}`)
+  pass('B3 wrong guest cannot read', `status=${wrongRead.status}`)
+
+  const noHeaderRead = await request(`/carts/${cartId}`)
+  assert([401, 403, 404].includes(noHeaderRead.status), `Expected 401/403/404 without header, got ${noHeaderRead.status}`)
+  pass('B4 missing header cannot read', `status=${noHeaderRead.status}`)
+
+  const patched = await request(`/carts/${cartId}`, {
+    method: 'PATCH',
+    headers: { 'X-Guest-Id': state.guestId },
+    body: { items: [{ product: state.productId, quantity: 3 }] },
+  })
+  assert(patched.status === 200, `Expected 200 patching cart, got ${patched.status}`)
+  pass('B5 update cart')
+
+  const deleted = await request(`/carts/${cartId}`, {
+    method: 'DELETE',
+    headers: { 'X-Guest-Id': state.guestId },
+  })
+  assert(deleted.status === 200, `Expected 200 deleting cart, got ${deleted.status}`)
+  pass('B6 delete cart')
+
+  const createMissingHeader = await request('/carts', {
+    method: 'POST',
+    body: { items: [{ product: state.productId, quantity: 1 }] },
+  })
+  assert([400, 403].includes(createMissingHeader.status), `Expected 400/403 create without header, got ${createMissingHeader.status}`)
+  pass('B7 create without header blocked', `status=${createMissingHeader.status}`)
+
+  const createInvalidGuest = await request('/carts', {
+    method: 'POST',
+    headers: { 'X-Guest-Id': 'not-a-uuid' },
+    body: { items: [{ product: state.productId, quantity: 1 }] },
+  })
+  assert([400, 403].includes(createInvalidGuest.status), `Expected 400/403 create invalid guest id, got ${createInvalidGuest.status}`)
+  pass('B8 invalid guest id blocked', `status=${createInvalidGuest.status}`)
+}
+
+async function testCheckoutAndLookup() {
+  logStep('C + D: Checkout and guest order lookup')
+
+  const cart = await createCart(state.guestId, 1)
+  assert(cart.status === 201 && cart.cartId, `Expected 201 creating checkout cart, got ${cart.status}`)
+
+  const okCheckout = await checkoutAsGuest({
+    cartId: cart.cartId,
+    guestId: state.guestId,
+    guestEmail: 'guest@example.com',
+    forwardedFor: ip(1),
+  })
+  assert(okCheckout.status === 201, `Expected 201 successful guest checkout, got ${okCheckout.status}`)
+  state.orderNumber = okCheckout.json?.order?.orderNumber || null
+  state.orderId = okCheckout.json?.order?.id || null
+  assert(state.orderNumber, 'Missing orderNumber from successful checkout')
+  pass('C1 successful guest checkout', `orderNumber=${state.orderNumber}`)
+
+  const cartMissing = await createCart(state.guestId, 1)
+  assert(cartMissing.status === 201 && cartMissing.cartId, 'Failed creating cart for C2')
+  const missingEmail = await request('/checkout/process', {
+    method: 'POST',
+    headers: { 'X-Guest-Id': state.guestId, 'x-forwarded-for': ip(2) },
+    body: {
+      cartId: cartMissing.cartId,
+      shippingAddress: { firstName: 'T', lastName: 'G', street1: '1', city: 'D', country: 'BD' },
+      billingAddress: { firstName: 'T', lastName: 'G', street1: '1', city: 'D', country: 'BD' },
+    },
+  })
+  assert(missingEmail.status === 400, `Expected 400 missing guestEmail, got ${missingEmail.status}`)
+  pass('C2 missing guestEmail blocked')
+
+  const cartInvalid = await createCart(state.guestId, 1)
+  assert(cartInvalid.status === 201 && cartInvalid.cartId, 'Failed creating cart for C3')
+  const invalidEmail = await checkoutAsGuest({
+    cartId: cartInvalid.cartId,
+    guestId: state.guestId,
+    guestEmail: 'not-an-email',
+    simulatePayment: false,
+    forwardedFor: ip(3),
+  })
+  assert(invalidEmail.status === 400, `Expected 400 invalid guestEmail, got ${invalidEmail.status}`)
+  pass('C3 invalid guestEmail blocked')
+
+  const cartMismatch = await createCart(state.guestId, 1)
+  assert(cartMismatch.status === 201 && cartMismatch.cartId, 'Failed creating cart for C4')
+  const mismatch = await checkoutAsGuest({
+    cartId: cartMismatch.cartId,
+    guestId: state.otherGuestId,
+    guestEmail: 'guest@example.com',
+    simulatePayment: false,
+    forwardedFor: ip(4),
+  })
+  assert(mismatch.status === 403, `Expected 403 cart ownership mismatch, got ${mismatch.status}`)
+  pass('C4 guest ownership enforced')
+
+  const cartIdempotent = await createCart(state.guestId, 1)
+  assert(cartIdempotent.status === 201 && cartIdempotent.cartId, 'Failed creating cart for C5')
+  const key = crypto.randomUUID()
+  const idempotentFirst = await checkoutAsGuest({
+    cartId: cartIdempotent.cartId,
+    guestId: state.guestId,
+    guestEmail: 'guest@example.com',
+    idempotencyKey: key,
+    forwardedFor: ip(5),
+  })
+  assert(idempotentFirst.status === 201, `Expected 201 idempotent first checkout, got ${idempotentFirst.status}`)
+  const firstOrderId = idempotentFirst.json?.order?.id
+
+  const idempotentSecond = await checkoutAsGuest({
+    cartId: cartIdempotent.cartId,
+    guestId: state.guestId,
+    guestEmail: 'guest@example.com',
+    idempotencyKey: key,
+    forwardedFor: ip(5),
+  })
+  assert(idempotentSecond.status === 201, `Expected 201 idempotent second checkout, got ${idempotentSecond.status}`)
+  const secondOrderId = idempotentSecond.json?.order?.id
+  assert(firstOrderId && secondOrderId && firstOrderId === secondOrderId, 'Idempotent retry did not return same order id')
+  pass('C5 idempotency returns same order')
+
+  const cartNorm = await createCart(state.guestId, 1)
+  assert(cartNorm.status === 201 && cartNorm.cartId, 'Failed creating cart for C6')
+  const normalizedEmail = '  Guest@Example.COM  '
+  const normCheckout = await checkoutAsGuest({
+    cartId: cartNorm.cartId,
+    guestId: state.guestId,
+    guestEmail: normalizedEmail,
+    forwardedFor: ip(6),
+  })
+  assert(normCheckout.status === 201, `Expected 201 normalized email checkout, got ${normCheckout.status}`)
+  const normOrderNumber = normCheckout.json?.order?.orderNumber
+  assert(normOrderNumber, 'Missing orderNumber for normalized-email checkout')
+  pass('C6 normalized guestEmail accepted')
+
+  const lookupOk = await request('/guest/order-lookup', {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip(201) },
+    body: { orderNumber: state.orderNumber, guestEmail: 'guest@example.com' },
+  })
+  assert(lookupOk.status === 200, `Expected 200 lookup success, got ${lookupOk.status}`)
+  pass('D1 lookup success')
+
+  const lookupWrongEmail = await request('/guest/order-lookup', {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip(202) },
+    body: { orderNumber: state.orderNumber, guestEmail: 'wrong@example.com' },
+  })
+  assert(lookupWrongEmail.status === 404, `Expected 404 wrong email lookup, got ${lookupWrongEmail.status}`)
+  pass('D2 wrong email returns 404')
+
+  const lookupWrongOrder = await request('/guest/order-lookup', {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip(203) },
+    body: { orderNumber: 'ORD-00000000-ZZZZ', guestEmail: 'guest@example.com' },
+  })
+  assert(lookupWrongOrder.status === 404, `Expected 404 wrong orderNumber lookup, got ${lookupWrongOrder.status}`)
+  pass('D3 wrong order returns 404')
+
+  const lookupMissingField = await request('/guest/order-lookup', {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip(204) },
+    body: { orderNumber: state.orderNumber },
+  })
+  assert(lookupMissingField.status === 400, `Expected 400 missing guestEmail lookup, got ${lookupMissingField.status}`)
+  pass('D4 missing field validation')
+}
+
+async function testAbuseScenarios() {
+  logStep('E: Abuse / penetration checks')
+
+  // E1: idempotency key must not be reusable across different guest contexts.
+  const key = crypto.randomUUID()
+  const guest1Email = 'guest-one@example.com'
+  const guest2Email = 'guest-two@example.com'
+
+  const c1 = await createCart(state.guestId, 1)
+  assert(c1.status === 201 && c1.cartId, `Failed creating cart for E1 guest1 (${c1.status})`)
+  const g1 = await checkoutAsGuest({
+    cartId: c1.cartId,
+    guestId: state.guestId,
+    guestEmail: guest1Email,
+    idempotencyKey: key,
+    forwardedFor: ip(31),
+  })
+  assert(g1.status === 201, `Expected 201 for first idempotent checkout in E1, got ${g1.status}`)
+
+  const c2 = await createCart(state.otherGuestId, 1)
+  assert(c2.status === 201 && c2.cartId, `Failed creating cart for E1 guest2 (${c2.status})`)
+  const g2 = await checkoutAsGuest({
+    cartId: c2.cartId,
+    guestId: state.otherGuestId,
+    guestEmail: guest2Email,
+    idempotencyKey: key,
+    forwardedFor: ip(32),
+  })
+  assert(g2.status === 409, `Expected 409 on cross-guest idempotency reuse, got ${g2.status}`)
+  pass('E1 cross-guest idempotency reuse blocked')
+
+  // E2: authenticated customer cannot checkout a guest cart.
+  if (!state.authToken && AUTH_TOKEN) {
+    state.authToken = AUTH_TOKEN
+    state.authUserEmail = 'token-user@example.com'
+  }
+
+  if (!state.authToken) {
+    try {
+      const auth = await registerAndLoginCustomer()
+      state.authToken = auth.token
+      state.authUserEmail = auth.email
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes('Email address is not verified')) {
+        skip('E2 authenticated user cannot checkout guest cart', 'login blocked by verification policy; provide AUTH_TOKEN to run')
+        return
+      }
+      throw err
+    }
+  }
+
+  const guestCart = await createCart(state.guestId, 1)
+  assert(guestCart.status === 201 && guestCart.cartId, `Failed creating guest cart for E2 (${guestCart.status})`)
+  const authCheckout = await request('/checkout/process', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${state.authToken}`,
+      'x-forwarded-for': ip(33),
+    },
+    body: {
+      cartId: guestCart.cartId,
+      guestEmail: state.authUserEmail, // attempt bypass by supplying guestEmail while authenticated
+      shippingAddress: { firstName: 'A', lastName: 'B', street1: '1', city: 'D', country: 'BD' },
+      billingAddress: { firstName: 'A', lastName: 'B', street1: '1', city: 'D', country: 'BD' },
+    },
+  })
+  assert(authCheckout.status === 403, `Expected 403 authenticated user on guest cart checkout, got ${authCheckout.status}`)
+  pass('E2 authenticated user cannot checkout guest cart')
+}
+
+async function testRateLimits() {
+  logStep('F: Rate limit checks (optional)')
+
+  const lookupIp = ip(241)
+  const codesLookup = []
+  for (let i = 0; i < 11; i++) {
+    const r = await request('/guest/order-lookup', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': lookupIp },
+      body: { orderNumber: 'ORD-00000000-ZZZZ', guestEmail: 'test@example.com' },
+    })
+    codesLookup.push(r.status)
+  }
+  assert(codesLookup.slice(0, 10).every((c) => c === 404), `Expected first 10 lookup requests to be 404, got ${codesLookup.join(',')}`)
+  assert(codesLookup[10] === 429, `Expected 11th guest lookup request to be 429, got ${codesLookup[10]}`)
+  pass('D6 guest lookup rate limit', `codes=${codesLookup.join(',')}`)
+
+  const checkoutIp = ip(242)
+  const codesCheckout = []
+  for (let i = 0; i < 6; i++) {
+    const r = await request('/checkout/process', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': checkoutIp },
+      body: {
+        cartId: 'nonexistent',
+        guestEmail: 'a@b.com',
+        shippingAddress: { firstName: 'T', lastName: 'G', street1: '1', city: 'D', country: 'BD' },
+        billingAddress: { firstName: 'T', lastName: 'G', street1: '1', city: 'D', country: 'BD' },
+      },
+    })
+    codesCheckout.push(r.status)
+  }
+  assert(codesCheckout.slice(0, 5).every((c) => c === 404), `Expected first 5 checkout requests to be 404, got ${codesCheckout.join(',')}`)
+  assert(codesCheckout[5] === 429, `Expected 6th checkout request to be 429, got ${codesCheckout[5]}`)
+  pass('F checkout rate limit', `codes=${codesCheckout.join(',')}`)
+}
+
+function printSummaryAndExit() {
+  const failed = summary.filter((x) => !x.ok)
+  const skipped = summary.filter((x) => x.skipped)
+  console.log('\n=== Guest checkout test summary ===')
+  for (const row of summary) {
+    const label = row.skipped ? 'SKIP' : row.ok ? 'PASS' : 'FAIL'
+    console.log(`${label} - ${row.name}${row.detail ? ` (${row.detail})` : ''}`)
+  }
+  const passed = summary.length - failed.length - skipped.length
+  console.log(`\nTotal: ${summary.length}, Passed: ${passed}, Skipped: ${skipped.length}, Failed: ${failed.length}`)
+  process.exit(failed.length ? 1 : 0)
+}
+
+async function main() {
+  console.log('Running guest checkout backend test suite')
+  console.log(`API_BASE=${API_BASE}`)
+  console.log(`GUEST_ID=${state.guestId}`)
+  console.log(`RUN_RATE_LIMIT=${RUN_RATE_LIMIT}`)
+
+  try {
+    logStep('Resolve product')
+    state.productId = await resolveProductId()
+    console.log(`  Using product id: ${state.productId}${process.env.PRODUCT_ID ? ' (from PRODUCT_ID)' : ' (first published)'}`)
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err)
+    process.exit(1)
+  }
+
+  try {
+    await testCartLifecycle()
+  } catch (err) {
+    fail('B cart lifecycle', err instanceof Error ? err.message : String(err))
+  }
+
+  try {
+    await testCheckoutAndLookup()
+  } catch (err) {
+    fail('C/D checkout+lookup', err instanceof Error ? err.message : String(err))
+  }
+
+  try {
+    await testAbuseScenarios()
+  } catch (err) {
+    fail('E abuse scenarios', err instanceof Error ? err.message : String(err))
+  }
+
+  if (RUN_RATE_LIMIT) {
+    try {
+      await testRateLimits()
+    } catch (err) {
+      fail('D6/F rate limits', err instanceof Error ? err.message : String(err))
+    }
+  } else {
+    console.log('\nSkipping rate-limit checks. Set RUN_RATE_LIMIT=true to include them.')
+  }
+
+  printSummaryAndExit()
+}
+
+main().catch((err) => {
+  console.error('Unexpected test runner error:', err)
+  process.exit(1)
+})

--- a/packages/backend/src/endpoints/guest-order-lookup.ts
+++ b/packages/backend/src/endpoints/guest-order-lookup.ts
@@ -1,0 +1,70 @@
+/**
+ * Guest order lookup endpoint.
+ *
+ * POST /api/guest/order-lookup
+ *
+ * Requires both `orderNumber` and `guestEmail`. Returns the matching guest
+ * order (customer=null) or 404. Rate-limited to prevent brute-force email
+ * enumeration.
+ *
+ * Security:
+ * - Both factors required — orderNumber alone is insufficient.
+ * - Only guest orders returned (customer IS NULL).
+ * - Uniform 404 for wrong email and wrong orderNumber (no info leak).
+ * - Rate limited: 10 requests per 15 minutes per IP.
+ */
+import type { Endpoint } from 'payload'
+import {
+  createRateLimiter,
+  enforceRateLimit,
+  getClientIp,
+  GUEST_LOOKUP_RATE_LIMIT,
+} from '../lib/rate-limiter'
+
+const guestLookupLimiter = createRateLimiter({
+  ...GUEST_LOOKUP_RATE_LIMIT,
+  keyPrefix: 'rl:guest-lookup',
+})
+
+export const guestOrderLookupEndpoint: Endpoint = {
+  path: '/guest/order-lookup',
+  method: 'post',
+  handler: async (req) => {
+    // ── Rate limiting ─────────────────────────────────────────────────────
+    const clientIp = getClientIp(req as unknown as Request)
+    const limitResponse = await enforceRateLimit(guestLookupLimiter, clientIp)
+    if (limitResponse) return limitResponse
+
+    // ── Parse body ────────────────────────────────────────────────────────
+    const data = (await (req as Request).json?.().catch(() => ({}))) || {}
+    const { orderNumber, guestEmail } = data
+
+    if (!orderNumber || typeof orderNumber !== 'string' || !orderNumber.trim()) {
+      return Response.json({ error: 'orderNumber is required' }, { status: 400 })
+    }
+    if (!guestEmail || typeof guestEmail !== 'string' || !guestEmail.trim()) {
+      return Response.json({ error: 'guestEmail is required' }, { status: 400 })
+    }
+
+    // ── Query: both orderNumber + guestEmail must match, customer must be null ─
+    const result = await req.payload.find({
+      collection: 'orders',
+      where: {
+        and: [
+          { orderNumber: { equals: orderNumber.trim() } },
+          { guestEmail: { equals: guestEmail.trim().toLowerCase() } },
+          { customer: { equals: null } },
+        ],
+      },
+      limit: 1,
+      depth: 2,
+      overrideAccess: true,
+    })
+
+    if (!result.docs.length) {
+      return Response.json({ error: 'Order not found' }, { status: 404 })
+    }
+
+    return Response.json({ order: result.docs[0] }, { status: 200 })
+  },
+}

--- a/packages/backend/src/lib/process-checkout.ts
+++ b/packages/backend/src/lib/process-checkout.ts
@@ -50,6 +50,7 @@ export interface ProcessCheckoutInput {
   guestEmail?: string
   simulatePayment?: boolean
   currency?: string
+  idempotencyKey?: string
 }
 
 export interface ProcessCheckoutResult {
@@ -65,11 +66,56 @@ export async function processCheckout(
   userId?: string | number,
   req?: PayloadRequest
 ): Promise<ProcessCheckoutResult> {
-  const { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment = false } = input
+  const { cartId, shippingAddress, billingAddress, simulatePayment = false, idempotencyKey } = input
+  // Normalize guestEmail once: trim + lowercase so stored value always matches lookup queries
+  const guestEmail = input.guestEmail ? input.guestEmail.trim().toLowerCase() : undefined
+  const isAdminUser = (req?.user as { role?: string } | undefined)?.role === 'admin'
+
+  if (!userId && !guestEmail) {
+    return { order: { id: '', orderNumber: '' }, error: 'Guest checkout requires guestEmail', statusCode: 400 }
+  }
+
+  // ── Idempotency: return existing order if key was already used ──────────
+  if (idempotencyKey) {
+    const existing = await payload.find({
+      collection: 'orders',
+      where: { idempotencyKey: { equals: idempotencyKey } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    })
+    if (existing.docs.length > 0) {
+      const existingOrder = existing.docs[0] as {
+        id: string
+        orderNumber: string
+        customer?: { id: string } | string | null
+        guestEmail?: string | null
+      }
+      const existingCustomerId =
+        existingOrder.customer != null
+          ? (typeof existingOrder.customer === 'object' ? existingOrder.customer.id : String(existingOrder.customer))
+          : null
+      const existingGuestEmail = existingOrder.guestEmail ? String(existingOrder.guestEmail).trim().toLowerCase() : null
+
+      if (userId) {
+        if (isAdminUser || existingCustomerId === String(userId)) {
+          return { order: { id: existingOrder.id, orderNumber: existingOrder.orderNumber } }
+        }
+      } else if (!existingCustomerId && existingGuestEmail && existingGuestEmail === guestEmail) {
+        return { order: { id: existingOrder.id, orderNumber: existingOrder.orderNumber } }
+      }
+
+      return {
+        order: { id: '', orderNumber: '' },
+        error: 'idempotencyKey is already used by another checkout context',
+        statusCode: 409,
+      }
+    }
+  }
 
   // Optional: require verified identifier for logged-in checkout
   const requireVerifiedForCheckout = process.env.REQUIRE_VERIFIED_FOR_CHECKOUT === 'true'
-  if (requireVerifiedForCheckout && userId && !guestEmail) {
+  if (requireVerifiedForCheckout && userId && !isAdminUser) {
     const user = await payload.findByID({
       collection: 'users',
       id: userId,
@@ -91,12 +137,31 @@ export async function processCheckout(
       collection: 'carts',
       id: cartId,
       depth: 2,
+      overrideAccess: true, // Access enforced below via ownership check
     })
   } catch (err) {
     if (err instanceof NotFound) {
       return { order: { id: '', orderNumber: '' }, error: 'Cart not found', statusCode: 404 }
     }
     throw err
+  }
+
+  // ── Ownership verification ──────────────────────────────────────────────
+  // Prevent a guest from checking out another guest's cart, or an authenticated
+  // user from checking out a cart that doesn't belong to them.
+  const cartDoc = cart as { user?: { id: string } | string | null; guestId?: string | null }
+  if (!userId) {
+    // Guest checkout: verify guestId on cart matches X-Guest-Id header
+    const headerGuestId = req?.headers?.get?.('x-guest-id')
+    if (!headerGuestId || cartDoc.guestId !== headerGuestId) {
+      return { order: { id: '', orderNumber: '' }, error: 'Cart does not belong to this guest', statusCode: 403 }
+    }
+  } else {
+    // Authenticated checkout: verify cart belongs to this user (skip for admin)
+    const cartUserId = typeof cartDoc.user === 'object' ? cartDoc.user?.id : cartDoc.user
+    if (!isAdminUser && (!cartUserId || cartUserId !== String(userId))) {
+      return { order: { id: '', orderNumber: '' }, error: 'Cart does not belong to this user', statusCode: 403 }
+    }
   }
 
   const items = cart.items as Array<{
@@ -108,10 +173,6 @@ export async function processCheckout(
 
   if (!items?.length) {
     return { order: { id: '', orderNumber: '' }, error: 'Cart is empty' }
-  }
-
-  if (!userId && !guestEmail) {
-    return { order: { id: '', orderNumber: '' }, error: 'Guest checkout requires guestEmail' }
   }
 
   const currency = input.currency || getDefaultCurrency()
@@ -232,6 +293,7 @@ export async function processCheckout(
     }
     if (userId) orderData.customer = userId
     if (guestEmail) orderData.guestEmail = guestEmail
+    if (idempotencyKey) orderData.idempotencyKey = idempotencyKey
     if (splitByVendor) orderData.subOrders = []
 
     order = await payload.create({

--- a/packages/backend/src/lib/rate-limiter.ts
+++ b/packages/backend/src/lib/rate-limiter.ts
@@ -1,0 +1,125 @@
+/**
+ * Redis-backed rate limiter utility.
+ *
+ * Uses `rate-limiter-flexible` with an `ioredis` client for sliding-window
+ * rate limiting on custom endpoints (checkout, guest order lookup, etc.).
+ *
+ * Fail-open: if Redis is unavailable, requests are allowed through with a
+ * warning log. This prevents Redis downtime from blocking checkout.
+ */
+import Redis from 'ioredis'
+import { RateLimiterRedis } from 'rate-limiter-flexible'
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+// ── Lazy Redis client ─────────────────────────────────────────────────────────
+let _redis: Redis | null = null
+
+function getRedisClient(): Redis {
+  if (!_redis) {
+    _redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379', {
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      lazyConnect: true,
+    })
+    _redis.connect().catch((err) => {
+      console.warn('[rate-limiter] Redis connection failed — rate limiting disabled:', err.message)
+    })
+  }
+  return _redis
+}
+
+// ── Rate limit presets ────────────────────────────────────────────────────────
+
+/** 5 requests per 60 seconds per IP */
+export const CHECKOUT_RATE_LIMIT = {
+  points: envInt('CHECKOUT_RATE_LIMIT_POINTS', 5),
+  duration: envInt('CHECKOUT_RATE_LIMIT_DURATION_SECONDS', 60),
+} as const
+
+/** 10 requests per 15 minutes per IP */
+export const GUEST_LOOKUP_RATE_LIMIT = {
+  points: envInt('GUEST_LOOKUP_RATE_LIMIT_POINTS', 10),
+  duration: envInt('GUEST_LOOKUP_RATE_LIMIT_DURATION_SECONDS', 900),
+} as const
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export interface RateLimitConfig {
+  points: number
+  duration: number
+  keyPrefix: string
+}
+
+/**
+ * Creates a Redis-backed rate limiter instance.
+ *
+ * @example
+ * const limiter = createRateLimiter({ ...CHECKOUT_RATE_LIMIT, keyPrefix: 'rl:checkout' })
+ */
+export function createRateLimiter(config: RateLimitConfig): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: getRedisClient(),
+    points: config.points,
+    duration: config.duration,
+    keyPrefix: config.keyPrefix,
+  })
+}
+
+// ── Enforcement helper ────────────────────────────────────────────────────────
+
+/**
+ * Attempts to consume one rate-limit point for `key`.
+ *
+ * Returns a 429 `Response` if the limit is exceeded, or `null` if the request
+ * is within limits. On Redis errors, logs a warning and returns `null`
+ * (fail-open).
+ */
+export async function enforceRateLimit(
+  limiter: RateLimiterRedis,
+  key: string,
+): Promise<Response | null> {
+  try {
+    await limiter.consume(key)
+    return null
+  } catch (err: unknown) {
+    // rate-limiter-flexible throws a RateLimiterRes when the limit is exceeded
+    if (err && typeof err === 'object' && 'msBeforeNext' in err) {
+      const retryAfter = Math.ceil(Number((err as { msBeforeNext: number }).msBeforeNext) / 1000)
+      return new Response(
+        JSON.stringify({ error: 'Too many requests. Please try again later.' }),
+        {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'Retry-After': String(retryAfter),
+          },
+        },
+      )
+    }
+    // Redis unavailable or other error — fail open
+    console.warn('[rate-limiter] Redis error — allowing request through:', (err as Error)?.message)
+    return null
+  }
+}
+
+// ── IP extraction ─────────────────────────────────────────────────────────────
+
+/**
+ * Extracts the client IP from request headers.
+ * Uses `x-forwarded-for` (first IP in chain) when behind a reverse proxy,
+ * falls back to a static key.
+ */
+export function getClientIp(req: Request): string {
+  const forwarded = req.headers.get('x-forwarded-for')
+  if (forwarded) {
+    // x-forwarded-for can be comma-separated; take the first (client) IP
+    return forwarded.split(',')[0].trim()
+  }
+  return 'unknown'
+}

--- a/packages/backend/src/lib/utils.ts
+++ b/packages/backend/src/lib/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared utility functions.
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Validates that a string is a well-formed UUID (v1–v5, any case). */
+export function isValidUUID(value: string): boolean {
+  return UUID_RE.test(value)
+}

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -34,6 +34,11 @@ import { PlatformSettings } from './globals/platform-settings'
 import { redisConfig, cachedCollections } from './lib/redis'
 import { processCheckout } from './lib/process-checkout'
 import { authLoginEndpoint } from './endpoints/auth-login'
+import { guestOrderLookupEndpoint } from './endpoints/guest-order-lookup'
+import { createRateLimiter, enforceRateLimit, getClientIp, CHECKOUT_RATE_LIMIT } from './lib/rate-limiter'
+import { isValidUUID } from './lib/utils'
+
+const checkoutLimiter = createRateLimiter({ ...CHECKOUT_RATE_LIMIT, keyPrefix: 'rl:checkout' })
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -109,18 +114,29 @@ export default buildConfig({
   // ─── Custom Endpoints ────────────────────────────────────────────────────────
   endpoints: [
     authLoginEndpoint,
+    guestOrderLookupEndpoint,
     {
       path: '/checkout/process',
       method: 'post',
       handler: async (req) => {
+        // ── Rate limiting (by IP) ───────────────────────────────────────────
+        const clientIp = getClientIp(req as unknown as Request)
+        const limitResponse = await enforceRateLimit(checkoutLimiter, clientIp)
+        if (limitResponse) return limitResponse
+
         const data = (await (req as Request).json?.().catch(() => ({}))) || {}
-        const { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment = false } = data
+        const { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment = false, idempotencyKey } = data
 
         if (!cartId || !shippingAddress || !billingAddress) {
           return Response.json(
             { error: 'Missing required fields: cartId, shippingAddress, billingAddress' },
             { status: 400 }
           )
+        }
+
+        // Validate idempotencyKey format if provided
+        if (idempotencyKey !== undefined && (typeof idempotencyKey !== 'string' || !isValidUUID(idempotencyKey))) {
+          return Response.json({ error: 'idempotencyKey must be a valid UUID string' }, { status: 400 })
         }
 
         const requiredAddressFields = ['firstName', 'lastName', 'street1', 'city', 'country']
@@ -140,11 +156,26 @@ export default buildConfig({
             { status: 400 }
           )
         }
+        // Validate guestEmail format for guest checkout
+        if (!userId && guestEmail) {
+          const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+          if (typeof guestEmail !== 'string' || !emailRe.test(guestEmail.trim())) {
+            return Response.json(
+              { error: 'guestEmail must be a valid email address' },
+              { status: 400 }
+            )
+          }
+        }
+
+        // simulatePayment: only allow in development or for admin users
+        const isAdminUser = req.user?.role === 'admin'
+        const isDev = process.env.NODE_ENV === 'development'
+        const safeSimulatePayment = (isAdminUser || isDev) ? (simulatePayment === true) : false
 
         try {
           const result = await processCheckout(
             req.payload,
-            { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment },
+            { cartId, shippingAddress, billingAddress, guestEmail, simulatePayment: safeSimulatePayment, idempotencyKey },
             userId,
             req
           )

--- a/packages/backend/src/plugins/ecommerce/collections/carts.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/carts.ts
@@ -1,5 +1,6 @@
-import { APIError, type CollectionConfig } from 'payload'
+import { APIError, type CollectionConfig, type Where } from 'payload'
 import { validateCouponForSubtotal } from '../../discounts/lib/coupon'
+import { isValidUUID } from '../../../lib/utils'
 
 const itemFieldsBase = [
   {
@@ -23,7 +24,7 @@ const itemFieldsBase = [
   },
 ]
 
-export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig {
+export function createCartsConfig(multivendorEnabled: boolean, allowGuestCheckout = false): CollectionConfig {
   const itemFields = [
     ...itemFieldsBase.slice(0, 2),
     ...(multivendorEnabled
@@ -39,6 +40,29 @@ export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig
     ...itemFieldsBase.slice(2),
   ]
 
+  // ── Guest-aware access helpers ────────────────────────────────────────────
+  // When allowGuestCheckout is true, unauthenticated requests with a valid
+  // X-Guest-Id header can access carts matching their guestId (and only
+  // carts without a user — prevents accessing authenticated users' carts).
+
+  function guestReadFilter(req: {
+    user?: { id: string | number; role?: string } | null
+    headers: { get(name: string): string | null }
+  }): boolean | Where {
+    if (req.user?.role === 'admin') return true
+    if (req.user) return { user: { equals: req.user.id } } as Where
+    if (!allowGuestCheckout) return false
+
+    const guestId = req.headers.get('x-guest-id')
+    if (!guestId || !isValidUUID(guestId)) return false
+    return {
+      and: [
+        { guestId: { equals: guestId } },
+        { user: { equals: null } },
+      ],
+    } as Where
+  }
+
   return {
   slug: 'carts',
   admin: {
@@ -50,6 +74,23 @@ export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig
     beforeChange: [
       async ({ data, req, operation }) => {
         if (!data) return data
+
+        // ── Guest cart: assign guestId from header, never from body ────────
+        if (!req.user) {
+          if (operation === 'create') {
+            const headerGuestId = req.headers.get('x-guest-id')
+            if (!headerGuestId || !isValidUUID(headerGuestId)) {
+              throw new APIError('X-Guest-Id header with a valid UUID is required for guest cart creation', 400)
+            }
+            data.guestId = headerGuestId
+            data.user = undefined // Guest carts never have a user
+            // Default expiry: 7 days from now
+            if (!data.expiresAt) {
+              data.expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+            }
+          }
+          // On update: do not modify guestId — it was set on create
+        }
 
         // User assignment: customers can only create/update for self; admin can set any user.
         if (req.user?.id != null) {
@@ -134,22 +175,15 @@ export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig
     ],
   },
   access: {
-    create: ({ req }) => Boolean(req.user),
-    read: ({ req }) => {
-      if (req.user?.role === 'admin') return true
-      if (req.user) return { user: { equals: req.user.id } }
-      return false
+    create: ({ req }) => {
+      if (req.user) return true
+      if (!allowGuestCheckout) return false
+      const guestId = req.headers.get('x-guest-id')
+      return Boolean(guestId && isValidUUID(guestId))
     },
-    update: ({ req }) => {
-      if (req.user?.role === 'admin') return true
-      if (req.user) return { user: { equals: req.user.id } }
-      return false
-    },
-    delete: ({ req }) => {
-      if (req.user?.role === 'admin') return true
-      if (req.user) return { user: { equals: req.user.id } }
-      return false
-    },
+    read: ({ req }) => guestReadFilter(req),
+    update: ({ req }) => guestReadFilter(req),
+    delete: ({ req }) => guestReadFilter(req),
   },
   fields: [
     {
@@ -162,7 +196,7 @@ export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig
       name: 'guestId',
       type: 'text',
       index: true,
-      admin: { description: 'UUID for guest identification.' },
+      admin: { description: 'UUID for guest identification. Set from X-Guest-Id header; never from body.' },
     },
     {
       name: 'items',
@@ -203,7 +237,7 @@ export function createCartsConfig(multivendorEnabled: boolean): CollectionConfig
     {
       name: 'expiresAt',
       type: 'date',
-      admin: { description: 'Guest carts expire.' },
+      admin: { description: 'Guest carts expire. Auto-set to 7 days on guest create.' },
     },
   ],
   timestamps: true,

--- a/packages/backend/src/plugins/ecommerce/index.ts
+++ b/packages/backend/src/plugins/ecommerce/index.ts
@@ -15,7 +15,7 @@ export interface EcommercePluginOptions {
 export const ecommercePlugin =
   (options: EcommercePluginOptions = {}): Plugin =>
   (incomingConfig) => {
-    const { enabled = true, multivendorEnabled = false } = options
+    const { enabled = true, multivendorEnabled = false, allowGuestCheckout = false } = options
     if (!enabled) return incomingConfig
 
     return {
@@ -24,7 +24,7 @@ export const ecommercePlugin =
         ...(incomingConfig.collections || []),
         createProductsConfig(multivendorEnabled),
         createProductVariantsConfig(multivendorEnabled),
-        createCartsConfig(multivendorEnabled),
+        createCartsConfig(multivendorEnabled, allowGuestCheckout),
         Addresses,
       ],
     }

--- a/packages/backend/src/plugins/orders/collections/orders.ts
+++ b/packages/backend/src/plugins/orders/collections/orders.ts
@@ -40,6 +40,16 @@ export function createOrdersConfig(splitByVendor: boolean): CollectionConfig {
       admin: { description: 'For guest checkout.' },
     },
     {
+      name: 'idempotencyKey',
+      type: 'text',
+      index: true,
+      admin: {
+        readOnly: true,
+        description:
+          'Client-supplied UUID for idempotent checkout. If an order with this key already exists, the existing order is returned without creating a duplicate.',
+      },
+    },
+    {
       name: 'status',
       type: 'select',
       required: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,6 +3166,11 @@ range-parser@1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+rate-limiter-flexible@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-10.0.1.tgz#eaede7a61b278e6b947c081bed5fb0ebfcf2532c"
+  integrity sha512-3G6GMFz5Oz5nVnDv9gQ1LLMdExR4B1lOjogPIjehtgyxPMIkY09BGyk2eCYt36/OkV/0t12GEt6J6HpTl6RzZg==
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"


### PR DESCRIPTION
## Summary

This PR finalizes Phase 6 guest checkout hardening and adds automated backend validation for both normal flows and abuse scenarios.

### ✅ Backend hardening

- Hardened `processCheckout` ownership/security logic:
  - guest checkout must match `X-Guest-Id` to cart `guestId`
  - authenticated non-admin users cannot checkout guest carts
  - authenticated users can only checkout their own carts
- Added context-scoped idempotency protection:
  - same `idempotencyKey` can only return an existing order for the same checkout context
  - cross-context reuse now returns `409` instead of leaking order identity
- Closed verification bypass path:
  - `REQUIRE_VERIFIED_FOR_CHECKOUT` correctly applies to logged-in users (non-admin)

### ✅ Endpoint validation / controls

- `POST /api/checkout/process`:
  - rate-limited by IP (Redis-backed)
  - validates `idempotencyKey` as UUID
  - validates guest email format for guest checkout
  - `simulatePayment` restricted to dev/admin
- `POST /api/guest/order-lookup` remains secured with:
  - `orderNumber + guestEmail` required
  - `customer = null` constraint (guest orders only)
  - uniform 404 behavior for mismatches

### ✅ Config + docs updates

- Added env-configurable rate limits in `.env.example`:
  - `CHECKOUT_RATE_LIMIT_POINTS`
  - `CHECKOUT_RATE_LIMIT_DURATION_SECONDS`
  - `GUEST_LOOKUP_RATE_LIMIT_POINTS`
  - `GUEST_LOOKUP_RATE_LIMIT_DURATION_SECONDS`
- Updated project docs/context:
  - `docs/PHASE-6-START.md` with guest hardening follow-up status
  - `docs/CONTEXT.md` refreshed for current Phase 6 context
  - `README.md` updated with guest test command + flags

### ✅ Automated test coverage

Added `packages/backend/scripts/test-guest-checkout.mjs` and command:

- `yarn test:guest`

Coverage includes:

- guest cart lifecycle (create/read/update/delete + header/ownership checks)
- guest checkout happy/failure flows
- idempotency behavior (same key returns same order)
- guest email normalization and lookup behavior
- abuse checks:
  - cross-guest idempotency reuse blocked
  - authenticated user cannot checkout guest cart
- optional rate-limit assertions (`RUN_RATE_LIMIT=true`)

## Test evidence

Executed successfully:

- `yarn typecheck`
- `RUN_RATE_LIMIT=true yarn test:guest`
- `AUTH_TOKEN=<customer1-token> RUN_RATE_LIMIT=false yarn test:guest`

Latest full run status:

- Passed: 22
- Skipped: 0
- Failed: 0

## Branch

- Base: `revamp/multivendor`
- Feature: `feature/revamp-phase-6-guest-checkout-hardening`

## Notes

- Current rate limiting trusts `x-forwarded-for` and is fail-open if Redis is unavailable (existing design choice). Further hardening can be done at proxy/edge level in a follow-up.