### PR TITLE
Phase 12: Multi-warehouse inventory, order line stockLevel, and vendor reassignment

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,6 +14,8 @@
     "test:cov:check": "c8 check-coverage",
     "test:e2e": "node tests/run-e2e.mjs",
     "test:e2e:safe": "node tests/run-e2e-safe.mjs",
+    "test:e2e:safe:profile": "node tests/run-e2e-safe.mjs",
+    "test:matrix:e2e:parallel": "node tests/run-all-profiles-safe-parallel-observe.mjs",
     "test:e2e:verification": "node tests/run-e2e.mjs --suite verification",
     "test:e2e:guest": "node tests/run-e2e.mjs --suite guest",
     "test:e2e:multivendor": "node tests/run-e2e.mjs --profile multivendor",

--- a/packages/backend/src/access/is-admin-or-vendor-stock-tenant.ts
+++ b/packages/backend/src/access/is-admin-or-vendor-stock-tenant.ts
@@ -1,0 +1,33 @@
+import type { Access } from 'payload'
+
+/**
+ * Read access for inventory rows scoped by stock-locations.tenant.
+ * Admin: all. Vendor: locations (and derived stock-levels) where location.tenant equals user.tenant.
+ * Platform warehouses (tenant null): admin only.
+ */
+export const stockLocationTenantRead: Access = ({ req }) => {
+  if (!req.user) return false
+  if (req.user.role === 'admin') return true
+  if (req.user.role === 'vendor' && req.user.tenant) {
+    const tid = typeof req.user.tenant === 'object' ? req.user.tenant.id : req.user.tenant
+    return {
+      tenant: {
+        equals: tid,
+      },
+    }
+  }
+  return false
+}
+
+/** Same tenant filter for stock-levels via nested location. */
+export const stockLevelTenantRead: Access = ({ req }) => {
+  if (!req.user) return false
+  if (req.user.role === 'admin') return true
+  if (req.user.role === 'vendor' && req.user.tenant) {
+    const tid = typeof req.user.tenant === 'object' ? req.user.tenant.id : req.user.tenant
+    return {
+      'location.tenant': { equals: tid },
+    } as any
+  }
+  return false
+}

--- a/packages/backend/src/lib/allocate-stock-level.ts
+++ b/packages/backend/src/lib/allocate-stock-level.ts
@@ -1,0 +1,118 @@
+/**
+ * Deterministic stock-level allocation for checkout: one warehouse row per order line.
+ * See docs/PHASE-12-MULTI-WAREHOUSE-INVENTORY.md
+ */
+import type { Payload, PayloadRequest } from 'payload'
+
+export type AllocateStockLevelArgs = {
+  productId: string
+  variantId: string | null
+  quantity: number
+  /** Product owner tenant; null = platform-owned product */
+  tenantId: string | null
+}
+
+export type AllocateStockLevelResult = { stockLevelId: string } | { error: string }
+
+function locationTenantId(loc: unknown): string | null {
+  if (!loc || typeof loc !== 'object') return null
+  const t = (loc as { tenant?: { id: string } | string | null }).tenant
+  if (t == null) return null
+  return typeof t === 'object' ? t.id : String(t)
+}
+
+function matchesProductVariant(
+  sl: {
+    product?: string | { id: string }
+    variant?: string | { id: string } | null
+  },
+  productId: string,
+  variantId: string | null
+): boolean {
+  const slProduct = typeof sl.product === 'object' ? sl.product?.id : sl.product
+  const slVariant = typeof sl.variant === 'object' ? sl.variant?.id : sl.variant
+  if (slProduct !== productId) return false
+  if (variantId) return slVariant === variantId
+  return slVariant == null || slVariant === undefined
+}
+
+function rowMatchesTenantFilter(
+  location: unknown,
+  productTenantId: string | null,
+  multivendor: boolean
+): boolean {
+  const locTenant = locationTenantId(location)
+  if (!multivendor) {
+    return locTenant == null
+  }
+  if (productTenantId == null) {
+    return locTenant == null
+  }
+  return locTenant === productTenantId
+}
+
+/**
+ * Pick a single stock-level document with enough available quantity (quantity - reservedQuantity).
+ * Sort candidates by id for stable ordering; prefer first row that can fulfill the full line quantity.
+ */
+export async function allocateStockLevelForLine(
+  payload: Payload,
+  args: AllocateStockLevelArgs,
+  _req?: PayloadRequest
+): Promise<AllocateStockLevelResult> {
+  const { productId, variantId, quantity, tenantId } = args
+  if (quantity < 1) {
+    return { error: 'Invalid quantity for stock allocation' }
+  }
+
+  const multivendor = process.env.MULTIVENDOR_ENABLED === 'true'
+
+  const { docs: rawDocs } = await payload.find({
+    collection: 'stock-levels',
+    where: { product: { equals: productId } },
+    limit: 500,
+    depth: 2,
+    overrideAccess: true,
+  })
+
+  const docs = rawDocs.filter((sl) => matchesProductVariant(sl as never, productId, variantId))
+
+  const candidates = (docs as Array<Record<string, unknown>>)
+    .filter((sl) => {
+      const loc = sl.location
+      return rowMatchesTenantFilter(loc, tenantId, multivendor)
+    })
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+
+  for (const sl of candidates) {
+    const q = Number(sl.quantity) || 0
+    const r = Number(sl.reservedQuantity) || 0
+    const available = q - r
+    if (available >= quantity) {
+      return { stockLevelId: String(sl.id) }
+    }
+  }
+
+  const totalAvailable = candidates.reduce((sum, sl) => {
+    const q = Number(sl.quantity) || 0
+    const r = Number(sl.reservedQuantity) || 0
+    return sum + (q - r)
+  }, 0)
+
+  if (candidates.length === 0) {
+    return {
+      error: 'No stock configured for this product at a warehouse for your seller.',
+    }
+  }
+
+  if (totalAvailable < quantity) {
+    return {
+      error: 'Insufficient stock across warehouses for this line.',
+    }
+  }
+
+  return {
+    error:
+      'Insufficient stock in a single warehouse for this quantity. Split the line or reduce quantity.',
+  }
+}

--- a/packages/backend/src/lib/build-reserve-quantities-by-stock-level.ts
+++ b/packages/backend/src/lib/build-reserve-quantities-by-stock-level.ts
@@ -1,0 +1,11 @@
+import type { CartItemForSplit } from '../plugins/orders/strategies/order-splitter'
+
+/** Aggregate line quantities by stock-level id for reservation (Phase 12). */
+export function buildReserveQuantitiesByStockLevel(orderItemData: CartItemForSplit[]): Map<string, number> {
+  const reserveByLevel = new Map<string, number>()
+  for (const d of orderItemData) {
+    if (!d.stockLevelId) continue
+    reserveByLevel.set(d.stockLevelId, (reserveByLevel.get(d.stockLevelId) || 0) + d.quantity)
+  }
+  return reserveByLevel
+}

--- a/packages/backend/src/lib/consume-order-inventory.ts
+++ b/packages/backend/src/lib/consume-order-inventory.ts
@@ -6,7 +6,7 @@
  * Used by: SubOrders afterChange (status -> shipped).
  */
 import type { Payload, PayloadRequest } from 'payload'
-import type { OrderItemLike } from './release-order-inventory'
+import { stockLevelIdFromItem, type OrderItemLike } from './release-order-inventory'
 
 export async function consumeOrderInventory(
   payload: Payload,
@@ -15,17 +15,46 @@ export async function consumeOrderInventory(
 ): Promise<void> {
   if (!items?.length) return
 
-  const productIds = [...new Set(items.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[])]
-  if (!productIds.length) return
+  const legacyItems = items.filter((i) => !stockLevelIdFromItem(i))
+  const productIds = [
+    ...new Set(legacyItems.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[]),
+  ]
 
-  const stockLevels = await payload.find({
-    collection: 'stock-levels',
-    where: { product: { in: productIds } },
-    limit: 100,
-    depth: 1,
-  })
+  const stockLevels =
+    productIds.length > 0
+      ? await payload.find({
+          collection: 'stock-levels',
+          where: { product: { in: productIds } },
+          limit: 100,
+          depth: 1,
+        })
+      : { docs: [] }
 
   for (const item of items) {
+    const directId = stockLevelIdFromItem(item)
+    if (directId) {
+      const quantity = Number(item.quantity) || 1
+      const levelDoc = await payload.findByID({
+        collection: 'stock-levels',
+        id: directId,
+        depth: 0,
+        overrideAccess: true,
+      })
+      if (!levelDoc) continue
+      const currentQty = Number((levelDoc as { quantity?: number }).quantity) || 0
+      const reserved = Number((levelDoc as { reservedQuantity?: number }).reservedQuantity) || 0
+      const newQuantity = Math.max(0, currentQty - quantity)
+      const newReserved = Math.max(0, reserved - quantity)
+      await payload.update({
+        collection: 'stock-levels',
+        id: directId,
+        overrideAccess: true,
+        data: { quantity: newQuantity, reservedQuantity: newReserved },
+        ...(req && { req }),
+      })
+      continue
+    }
+
     if (!item.product) continue
     const productId = typeof item.product === 'object' ? item.product?.id : item.product
     const variantId = item.variant

--- a/packages/backend/src/lib/order-item-relation-id.ts
+++ b/packages/backend/src/lib/order-item-relation-id.ts
@@ -1,0 +1,8 @@
+/** Normalize order-item relationship fields (string id, populated object, null). */
+export function orderItemRelationId(val: unknown): string | null {
+  if (val == null) return null
+  if (typeof val === 'object' && val !== null && 'id' in val) {
+    return String((val as { id: string }).id)
+  }
+  return String(val)
+}

--- a/packages/backend/src/lib/process-checkout.ts
+++ b/packages/backend/src/lib/process-checkout.ts
@@ -13,6 +13,8 @@ import { DefaultOrderSplitter, getPlatformItems } from '../plugins/orders/strate
 import type { CartItemForSplit } from '../plugins/orders/strategies/order-splitter'
 import { getCommissionRateForTenant, calculateCommission } from './commission'
 import { validateCouponForSubtotal } from '../plugins/discounts/lib/coupon'
+import { allocateStockLevelForLine } from './allocate-stock-level'
+import { buildReserveQuantitiesByStockLevel } from './build-reserve-quantities-by-stock-level'
 
 /** Creates req with transactionID when adapter supports transactions. */
 function reqWithTransaction(req: PayloadRequest | undefined, transactionID: string | number | null): PayloadRequest {
@@ -262,6 +264,30 @@ export async function processCheckout(
   }
   const grandTotal = Math.round((subtotalCalc + shippingTotal + taxTotal - discountTotal) * 100) / 100
 
+  const inventoryEnabled = process.env.INVENTORY_ENABLED !== 'false'
+  if (inventoryEnabled) {
+    for (const d of orderItemData) {
+      const alloc = await allocateStockLevelForLine(
+        payload,
+        {
+          productId: d.productId,
+          variantId: d.variantId,
+          quantity: d.quantity,
+          tenantId: d.tenantId,
+        },
+        req,
+      )
+      if ('error' in alloc) {
+        return {
+          order: { id: '', orderNumber: '' },
+          error: alloc.error,
+          statusCode: 400,
+        }
+      }
+      d.stockLevelId = alloc.stockLevelId
+    }
+  }
+
   const orderNumber = `ORD-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}-${Math.random().toString(36).substring(2, 6).toUpperCase()}`
 
   const transactionID = await payload.db.beginTransaction()
@@ -372,6 +398,7 @@ export async function processCheckout(
             productImage: d.productImage,
           }
           if (d.variantId != null) itemData.variant = d.variantId
+          if (inventoryEnabled && d.stockLevelId) itemData.stockLevel = d.stockLevelId
 
           const orderItem = await payload.create({
             collection: 'order-items',
@@ -407,6 +434,7 @@ export async function processCheckout(
           productImage: d.productImage,
         }
         if (d.variantId != null) itemData.variant = d.variantId
+        if (inventoryEnabled && d.stockLevelId) itemData.stockLevel = d.stockLevelId
 
         const orderItem = await payload.create({
           collection: 'order-items',
@@ -431,6 +459,7 @@ export async function processCheckout(
           productImage: d.productImage,
         }
         if (d.variantId != null) itemData.variant = d.variantId
+        if (inventoryEnabled && d.stockLevelId) itemData.stockLevel = d.stockLevelId
 
         const orderItem = await payload.create({
           collection: 'order-items',
@@ -510,35 +539,23 @@ export async function processCheckout(
       })
     }
 
-    // Reserve inventory
-    const productIds = [...new Set(items.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[])]
-    /* c8 ignore start — defensive: checkout items always resolve product ids; empty set skips DB query. */
-    const stockLevels: { docs: any[] } = productIds.length
-      ? await payload.find({
+    // Reserve inventory (Phase 12: aggregate by chosen stock-level id)
+    if (inventoryEnabled) {
+      const reserveByLevel = buildReserveQuantitiesByStockLevel(orderItemData)
+      for (const [stockLevelId, qty] of reserveByLevel) {
+        const levelDoc = await payload.findByID({
           collection: 'stock-levels',
-          where: { product: { in: productIds } },
-          limit: 100,
-          depth: 1,
+          id: stockLevelId,
+          depth: 0,
+          overrideAccess: true,
         })
-      : { docs: [] }
-    /* c8 ignore stop */
-    for (const item of items) {
-      const productId = typeof item.product === 'object' ? item.product?.id : item.product
-      const variantId = item.variant ? (typeof item.variant === 'object' ? item.variant?.id : item.variant) : null
-      const quantity = Number((item as { quantity: number }).quantity) || 1
-
-      const level = stockLevels.docs.find((sl: any) => {
-        const slProduct = typeof sl.product === 'object' ? sl.product?.id : sl.product
-        const slVariant = typeof sl.variant === 'object' ? sl.variant?.id : sl.variant
-        return slProduct === productId && (variantId ? slVariant === variantId : !slVariant)
-      })
-      if (level) {
-        const reserved = Number((level as any).reservedQuantity) || 0
+        if (!levelDoc) continue
+        const reserved = Number((levelDoc as { reservedQuantity?: number }).reservedQuantity) || 0
         await payload.update({
           collection: 'stock-levels',
-          id: level.id,
+          id: stockLevelId,
           overrideAccess: true,
-          data: { reservedQuantity: reserved + quantity },
+          data: { reservedQuantity: reserved + qty },
           req: reqTx,
         })
       }

--- a/packages/backend/src/lib/release-order-inventory.ts
+++ b/packages/backend/src/lib/release-order-inventory.ts
@@ -6,11 +6,19 @@
  */
 import type { Payload, PayloadRequest } from 'payload'
 
-/** Minimal shape for order items (product, variant, quantity). Used by Orders hooks. */
+/** Minimal shape for order items. Used by Orders hooks. */
 export type OrderItemLike = {
   product?: string | { id: string }
   variant?: string | { id: string } | null
   quantity?: number
+  /** When set (Phase 12), release uses this stock-level row only. */
+  stockLevel?: string | { id: string } | null
+}
+
+export function stockLevelIdFromItem(item: OrderItemLike): string | null {
+  const sl = item.stockLevel
+  if (sl == null) return null
+  return typeof sl === 'object' ? sl.id : String(sl)
 }
 
 export async function releaseOrderInventory(
@@ -20,17 +28,44 @@ export async function releaseOrderInventory(
 ): Promise<void> {
   if (!items?.length) return
 
-  const productIds = [...new Set(items.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[])]
-  if (!productIds.length) return
+  const legacyItems = items.filter((i) => !stockLevelIdFromItem(i))
+  const productIds = [
+    ...new Set(legacyItems.map((i) => (typeof i.product === 'object' ? i.product?.id : i.product)).filter(Boolean) as string[]),
+  ]
 
-  const stockLevels = await payload.find({
-    collection: 'stock-levels',
-    where: { product: { in: productIds } },
-    limit: 100,
-    depth: 1,
-  })
+  const stockLevels =
+    productIds.length > 0
+      ? await payload.find({
+          collection: 'stock-levels',
+          where: { product: { in: productIds } },
+          limit: 100,
+          depth: 1,
+        })
+      : { docs: [] }
 
   for (const item of items) {
+    const directId = stockLevelIdFromItem(item)
+    if (directId) {
+      const quantity = Number(item.quantity) || 1
+      const levelDoc = await payload.findByID({
+        collection: 'stock-levels',
+        id: directId,
+        depth: 0,
+        overrideAccess: true,
+      })
+      if (!levelDoc) continue
+      const reserved = Number((levelDoc as { reservedQuantity?: number }).reservedQuantity) || 0
+      const newReserved = Math.max(0, reserved - quantity)
+      await payload.update({
+        collection: 'stock-levels',
+        id: directId,
+        overrideAccess: true,
+        data: { reservedQuantity: newReserved },
+        ...(req && { req }),
+      })
+      continue
+    }
+
     if (!item.product) continue
     const productId = typeof item.product === 'object' ? item.product?.id : item.product
     const variantId = item.variant

--- a/packages/backend/src/lib/transfer-stock-reservation.ts
+++ b/packages/backend/src/lib/transfer-stock-reservation.ts
@@ -1,0 +1,58 @@
+/**
+ * Move reserved quantity from one stock-level row to another (order line warehouse change).
+ */
+import type { Payload, PayloadRequest } from 'payload'
+
+export async function transferStockReservation(
+  payload: Payload,
+  args: { fromStockLevelId: string; toStockLevelId: string; quantity: number },
+  req?: PayloadRequest
+): Promise<void> {
+  const { fromStockLevelId, toStockLevelId, quantity } = args
+  if (quantity < 1) return
+  if (fromStockLevelId === toStockLevelId) return
+
+  const fromDoc = await payload.findByID({
+    collection: 'stock-levels',
+    id: fromStockLevelId,
+    depth: 0,
+    overrideAccess: true,
+  })
+  const toDoc = await payload.findByID({
+    collection: 'stock-levels',
+    id: toStockLevelId,
+    depth: 0,
+    overrideAccess: true,
+  })
+  if (!fromDoc || !toDoc) {
+    throw new Error('Stock level not found')
+  }
+
+  const fromR = Number((fromDoc as { reservedQuantity?: number }).reservedQuantity) || 0
+  if (fromR < quantity) {
+    throw new Error('Source warehouse does not hold enough reserved quantity to transfer')
+  }
+
+  const toQ = Number((toDoc as { quantity?: number }).quantity) || 0
+  const toR = Number((toDoc as { reservedQuantity?: number }).reservedQuantity) || 0
+  const availableAtTarget = toQ - toR
+  if (availableAtTarget < quantity) {
+    throw new Error('Insufficient available capacity at target warehouse')
+  }
+
+  await payload.update({
+    collection: 'stock-levels',
+    id: fromStockLevelId,
+    overrideAccess: true,
+    data: { reservedQuantity: fromR - quantity },
+    ...(req && { req }),
+  })
+
+  await payload.update({
+    collection: 'stock-levels',
+    id: toStockLevelId,
+    overrideAccess: true,
+    data: { reservedQuantity: toR + quantity },
+    ...(req && { req }),
+  })
+}

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -138,6 +138,7 @@ export default buildConfig({
     }),
     inventoryPlugin({
       enabled: process.env.INVENTORY_ENABLED !== 'false',
+      multivendorEnabled: process.env.MULTIVENDOR_ENABLED === 'true',
       trackMovements: true,
       lowStockThreshold: Number(process.env.LOW_STOCK_THRESHOLD || '10'),
     }),

--- a/packages/backend/src/plugins/inventory/collections/stock-levels.ts
+++ b/packages/backend/src/plugins/inventory/collections/stock-levels.ts
@@ -1,40 +1,46 @@
 import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
+import { stockLevelTenantRead } from '../../../access/is-admin-or-vendor-stock-tenant'
 
-export const StockLevels: CollectionConfig = {
-  slug: 'stock-levels',
-  admin: {
-    useAsTitle: 'id',
-    defaultColumns: ['product', 'variant', 'location', 'quantity', 'reservedQuantity'],
-    group: 'Inventory',
-  },
-  access: {
-    create: isAdmin,
-    read: isAdmin,
-    update: isAdmin,
-    delete: isAdmin,
-  },
-  fields: [
-    {
-      name: 'product',
-      type: 'relationship',
-      relationTo: 'products',
-      required: true,
+export function createStockLevelsConfig(): CollectionConfig {
+  return {
+    slug: 'stock-levels',
+    admin: {
+      useAsTitle: 'id',
+      defaultColumns: ['product', 'variant', 'location', 'quantity', 'reservedQuantity'],
+      group: 'Inventory',
     },
-    {
-      name: 'variant',
-      type: 'relationship',
-      relationTo: 'product-variants',
-      admin: { description: 'Optional. Leave empty for product-level stock (no variants).' },
+    access: {
+      create: isAdmin,
+      read: stockLevelTenantRead,
+      update: isAdmin,
+      delete: isAdmin,
     },
-    {
-      name: 'location',
-      type: 'relationship',
-      relationTo: 'stock-locations',
-      required: true,
-    },
-    { name: 'quantity', type: 'number', required: true, min: 0 },
-    { name: 'reservedQuantity', type: 'number', defaultValue: 0, min: 0 },
-  ],
-  timestamps: true,
+    fields: [
+      {
+        name: 'product',
+        type: 'relationship',
+        relationTo: 'products',
+        required: true,
+      },
+      {
+        name: 'variant',
+        type: 'relationship',
+        relationTo: 'product-variants',
+        admin: { description: 'Optional. Leave empty for product-level stock (no variants).' },
+      },
+      {
+        name: 'location',
+        type: 'relationship',
+        relationTo: 'stock-locations',
+        required: true,
+      },
+      { name: 'quantity', type: 'number', required: true, min: 0 },
+      { name: 'reservedQuantity', type: 'number', defaultValue: 0, min: 0 },
+    ],
+    timestamps: true,
+  }
 }
+
+/** @deprecated use createStockLevelsConfig */
+export const StockLevels = createStockLevelsConfig()

--- a/packages/backend/src/plugins/inventory/collections/stock-locations.ts
+++ b/packages/backend/src/plugins/inventory/collections/stock-locations.ts
@@ -1,20 +1,9 @@
 import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
+import { stockLocationTenantRead } from '../../../access/is-admin-or-vendor-stock-tenant'
 
-export const StockLocations: CollectionConfig = {
-  slug: 'stock-locations',
-  admin: {
-    useAsTitle: 'name',
-    defaultColumns: ['name', 'code', 'isActive'],
-    group: 'Inventory',
-  },
-  access: {
-    create: isAdmin,
-    read: isAdmin,
-    update: isAdmin,
-    delete: isAdmin,
-  },
-  fields: [
+export function createStockLocationsConfig(multivendorEnabled: boolean): CollectionConfig {
+  const fields: NonNullable<CollectionConfig['fields']> = [
     { name: 'name', type: 'text', required: true },
     { name: 'code', type: 'text', required: true, unique: true },
     {
@@ -29,6 +18,36 @@ export const StockLocations: CollectionConfig = {
       ],
     },
     { name: 'isActive', type: 'checkbox', defaultValue: true },
-  ],
-  timestamps: true,
+  ]
+
+  if (multivendorEnabled) {
+    fields.splice(1, 0, {
+      name: 'tenant',
+      type: 'relationship',
+      relationTo: 'tenants',
+      admin: {
+        description: 'Vendor owning this warehouse. Leave empty for platform-managed warehouses.',
+      },
+    })
+  }
+
+  return {
+    slug: 'stock-locations',
+    admin: {
+      useAsTitle: 'name',
+      defaultColumns: multivendorEnabled ? ['name', 'code', 'tenant', 'isActive'] : ['name', 'code', 'isActive'],
+      group: 'Inventory',
+    },
+    access: {
+      create: isAdmin,
+      read: stockLocationTenantRead,
+      update: isAdmin,
+      delete: isAdmin,
+    },
+    fields,
+    timestamps: true,
+  }
 }
+
+/** @deprecated use createStockLocationsConfig */
+export const StockLocations = createStockLocationsConfig(false)

--- a/packages/backend/src/plugins/inventory/index.ts
+++ b/packages/backend/src/plugins/inventory/index.ts
@@ -1,9 +1,11 @@
 import type { Plugin } from 'payload'
-import { StockLocations } from './collections/stock-locations'
-import { StockLevels } from './collections/stock-levels'
+import { createStockLocationsConfig } from './collections/stock-locations'
+import { createStockLevelsConfig } from './collections/stock-levels'
 
 export interface InventoryPluginOptions {
   enabled?: boolean
+  /** When true, stock-locations includes tenant (requires multivendor plugin). */
+  multivendorEnabled?: boolean
   trackMovements?: boolean
   lowStockThreshold?: number
 }
@@ -11,15 +13,14 @@ export interface InventoryPluginOptions {
 export const inventoryPlugin =
   (options: InventoryPluginOptions = {}): Plugin =>
   (incomingConfig) => {
-    const { enabled = true } = options
+    const { enabled = true, multivendorEnabled = false } = options
     if (!enabled) return incomingConfig
+
+    const StockLocations = createStockLocationsConfig(multivendorEnabled)
+    const StockLevels = createStockLevelsConfig()
 
     return {
       ...incomingConfig,
-      collections: [
-        ...(incomingConfig.collections || []),
-        StockLocations,
-        StockLevels,
-      ],
+      collections: [...(incomingConfig.collections || []), StockLocations, StockLevels],
     }
   }

--- a/packages/backend/src/plugins/orders/collections/order-items.ts
+++ b/packages/backend/src/plugins/orders/collections/order-items.ts
@@ -1,6 +1,19 @@
 import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
 import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
+import { orderItemRelationId } from '../../../lib/order-item-relation-id'
+import { transferStockReservation } from '../../../lib/transfer-stock-reservation'
+
+/** True when PATCH value is the same as the stored document (Payload often merges full doc into `data`). */
+function vendorPatchValueUnchanged(incoming: unknown, previous: unknown): boolean {
+  if (incoming === previous) return true
+  const inc = orderItemRelationId(incoming)
+  const prev = orderItemRelationId(previous)
+  if (inc != null && prev != null) return inc === prev
+  /* Both nullish: relation id is only null when val == null, so values are absent-equivalent. */
+  if (inc == null && prev == null) return true
+  return false
+}
 
 export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig {
   const fields: NonNullable<CollectionConfig['fields']> = [
@@ -39,6 +52,15 @@ export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig
       type: 'relationship',
       relationTo: 'product-variants',
       admin: { description: 'Variant if applicable.' },
+    },
+    {
+      name: 'stockLevel',
+      type: 'relationship',
+      relationTo: 'stock-levels',
+      admin: {
+        description:
+          'Warehouse stock row used for fulfillment (Phase 12). Changes move reservation between warehouses.',
+      },
     },
     {
       name: 'productName',
@@ -80,8 +102,8 @@ export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig
     admin: {
       useAsTitle: 'itemLabel',
       defaultColumns: splitByVendor
-        ? ['order', 'subOrder', 'productName', 'variantName', 'quantity', 'unitPrice', 'totalPrice']
-        : ['order', 'productName', 'variantName', 'quantity', 'unitPrice', 'totalPrice'],
+        ? ['order', 'subOrder', 'productName', 'variantName', 'stockLevel', 'quantity', 'unitPrice', 'totalPrice']
+        : ['order', 'productName', 'variantName', 'stockLevel', 'quantity', 'unitPrice', 'totalPrice'],
       group: 'Orders',
       description: 'Line items for an order. Created at checkout from cart.',
     },
@@ -89,13 +111,39 @@ export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig
       create: isAdmin,
       // Vendors need read so relationship titles (itemLabel) resolve in admin when viewing sub-orders
       read: splitByVendor ? isAdminOrVendorOwner : isAdmin,
-      update: isAdmin,
+      update: splitByVendor ? isAdminOrVendorOwner : isAdmin,
       delete: isAdmin,
     },
     fields,
     timestamps: true,
     hooks: {
       beforeChange: [
+        ({ data, originalDoc, req, operation }) => {
+          if (operation === 'update' && req.user?.role === 'vendor' && data && originalDoc) {
+            const orig = originalDoc as Record<string, unknown>
+            const patch = data as Record<string, unknown>
+            for (const key of Object.keys(patch)) {
+              if (key === 'updatedAt') continue
+              if (key === 'stockLevel') continue
+              if (vendorPatchValueUnchanged(patch[key], orig[key])) continue
+              throw new Error('Vendors may only update fulfillment warehouse (stock level).')
+            }
+          }
+          return data
+        },
+        async ({ data, originalDoc, req, operation }) => {
+          if (operation !== 'update' || !data || data.stockLevel === undefined || !originalDoc) {
+            return data
+          }
+          const oldId = orderItemRelationId(originalDoc.stockLevel)
+          const newId = orderItemRelationId(data.stockLevel)
+          if (!oldId || !newId || oldId === newId) {
+            return data
+          }
+          const qty = Number(originalDoc.quantity) || 1
+          await transferStockReservation(req.payload, { fromStockLevelId: oldId, toStockLevelId: newId, quantity: qty }, req)
+          return data
+        },
         ({ data }) => {
           if (data?.productName != null) {
             /* c8 ignore next — Number() never returns null/undefined; ?? 1 is defensive. */

--- a/packages/backend/src/plugins/orders/strategies/order-splitter.ts
+++ b/packages/backend/src/plugins/orders/strategies/order-splitter.ts
@@ -15,6 +15,8 @@ export interface CartItemForSplit {
   productImage: string
   /** Vendor (tenant) ID. Null = platform-owned product. */
   tenantId: string | null
+  /** Set during checkout — chosen stock-levels row (Phase 12). */
+  stockLevelId?: string
 }
 
 export interface SubOrderSegment {

--- a/packages/backend/tests/_helpers/test-data-manager.mjs
+++ b/packages/backend/tests/_helpers/test-data-manager.mjs
@@ -300,7 +300,56 @@ export class TestDataManager {
     }
     const doc = res.json?.doc || res.json
     this.#track('products', doc?.id)
+    await this.#ensureStockForProductIfNeeded(doc)
     return doc
+  }
+
+  /**
+   * Phase 12: when inventory is on, checkout allocates a stock-level per line — seed a row for API-created products.
+   */
+  async #ensureStockForProductIfNeeded(productDoc) {
+    if (process.env.INVENTORY_ENABLED === 'false') return
+
+    const productId = String(productDoc?.id ?? '')
+    if (!productId) return
+
+    const multivendor = process.env.MULTIVENDOR_ENABLED === 'true'
+    const t = productDoc?.tenant
+    const tenantId =
+      t == null ? null : typeof t === 'object' && t !== null ? t.id : String(t)
+
+    const locBody = {
+      name: `E2E Default Warehouse ${this.#uid()}`,
+      code: `E2E-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`,
+      isActive: true,
+    }
+    if (multivendor && tenantId) {
+      locBody.tenant = tenantId
+    }
+
+    const locRes = await this.#request('/stock-locations', { method: 'POST', body: locBody })
+    if (![200, 201].includes(locRes.status)) {
+      throw new Error(`createProduct stock-location (${locRes.status}): ${locRes.text?.slice(0, 400)}`)
+    }
+    const loc = locRes.json?.doc || locRes.json
+    const locationId = loc?.id
+    if (!locationId) throw new Error('createProduct: missing stock-location id')
+    this.#track('stock-locations', locationId)
+
+    const slRes = await this.#request('/stock-levels', {
+      method: 'POST',
+      body: {
+        product: productId,
+        location: locationId,
+        quantity: 100_000,
+        reservedQuantity: 0,
+      },
+    })
+    if (![200, 201].includes(slRes.status)) {
+      throw new Error(`createProduct stock-level (${slRes.status}): ${slRes.text?.slice(0, 400)}`)
+    }
+    const sl = slRes.json?.doc || slRes.json
+    if (sl?.id) this.#track('stock-levels', sl.id)
   }
 
   async createTenant(overrides = {}) {
@@ -378,31 +427,65 @@ export class TestDataManager {
   }
 
   /**
-   * Delete all tracked entities in reverse creation order.
+   * Delete all tracked entities in FK-safe order (not strict reverse creation order).
+   * Example: carts reference products; stock-levels reference locations — delete children first.
    * Silently ignores 404s (already deleted / cascade).
    */
   async cleanup() {
-    const items = [...this.#created].reverse()
-    let errors = 0
-    for (const { collection, id } of items) {
-      try {
-        // Tenant teardown can violate FK constraints via deep references
-        // (products/order-items/sub-orders). Skip here; infra down -v resets DB
-        // in automated runs.
-        if (collection === 'tenants') {
-          continue
-        }
+    /** Lower index = delete first (dependents before parents). */
+    const CLEANUP_PRIORITY = [
+      'stock-levels',
+      'stock-locations',
+      'carts',
+      'order-items',
+      'sub-orders',
+      'transactions',
+      'orders',
+      'verification-codes',
+      'products',
+      'categories',
+      'coupons',
+      'users',
+    ]
 
-        const res = await this.#request(`/${collection}/${id}`, { method: 'DELETE' })
-        if (res.status !== 200 && res.status !== 404) {
-          if (this.#verbose) console.log(`  [DM] cleanup ${collection}/${id}: ${res.status}`)
+    const priority = (collection) => {
+      const i = CLEANUP_PRIORITY.indexOf(collection)
+      return i === -1 ? 1000 : i
+    }
+
+    const byColl = new Map()
+    for (const { collection, id } of this.#created) {
+      if (!byColl.has(collection)) byColl.set(collection, [])
+      byColl.get(collection).push(id)
+    }
+
+    const collections = [...byColl.keys()].sort((a, b) => {
+      const d = priority(a) - priority(b)
+      return d !== 0 ? d : a.localeCompare(b)
+    })
+
+    let errors = 0
+    const total = this.#created.length
+    for (const collection of collections) {
+      // Tenant teardown can violate FK constraints via deep references
+      // (products/order-items/sub-orders). Skip here; infra down -v resets DB
+      // in automated runs.
+      if (collection === 'tenants') continue
+
+      const ids = byColl.get(collection) || []
+      for (const id of [...ids].reverse()) {
+        try {
+          const res = await this.#request(`/${collection}/${id}`, { method: 'DELETE' })
+          if (res.status !== 200 && res.status !== 404) {
+            if (this.#verbose) console.log(`  [DM] cleanup ${collection}/${id}: ${res.status}`)
+            errors++
+          }
+        } catch {
           errors++
         }
-      } catch {
-        errors++
       }
     }
     this.#created = []
-    if (this.#verbose) console.log(`  [DM] cleanup complete (${items.length} items, ${errors} errors)`)
+    if (this.#verbose) console.log(`  [DM] cleanup complete (${total} items, ${errors} errors)`)
   }
 }

--- a/packages/backend/tests/e2e/checkout/multivendor-inventory-checkout.e2e.test.mjs
+++ b/packages/backend/tests/e2e/checkout/multivendor-inventory-checkout.e2e.test.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Multivendor + inventory E2E: guest checkout allocates a stock-level row per line
+ * and persists order-items.stockLevel (Phase 12).
+ *
+ * Requires: MULTIVENDOR_ENABLED=true, INVENTORY_ENABLED=true, GUEST_CHECKOUT_ENABLED=true.
+ * Skips with exit 0 when those are not met (e.g. default profile is not MV; all-gates has guest OFF).
+ *
+ * Cart must be created without Authorization so hooks set guestId from X-Guest-Id (see carts beforeChange).
+ */
+
+import crypto from 'node:crypto'
+import { createClient } from '../../_helpers/live-api-client.mjs'
+
+const { request, ok, fail, skip, logStep, printSummary } = createClient()
+const mv = process.env.MULTIVENDOR_ENABLED === 'true'
+const inv = process.env.INVENTORY_ENABLED !== 'false'
+const guestCheckout = process.env.GUEST_CHECKOUT_ENABLED !== 'false'
+const token = process.env.ADMIN_TOKEN
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg)
+}
+
+async function main() {
+  console.log('multivendor-inventory-checkout E2E | MV=' + mv + ' | INV=' + inv)
+
+  if (!mv || !inv) {
+    console.log('SKIP: requires MULTIVENDOR_ENABLED=true and INVENTORY_ENABLED=true')
+    process.exit(0)
+  }
+
+  // Guest cart + guest checkout require GUEST_CHECKOUT_ENABLED (e.g. all-gates profile has guest OFF).
+  if (!guestCheckout) {
+    console.log('SKIP: requires GUEST_CHECKOUT_ENABLED=true (guest cart API is disabled in this profile)')
+    process.exit(0)
+  }
+
+  if (!token) {
+    console.error('FAIL: ADMIN_TOKEN missing (run via tests/run-e2e.mjs)')
+    process.exit(1)
+  }
+
+  const auth = { Authorization: `Bearer ${token}` }
+  const guestId = crypto.randomUUID()
+  const suffix = `${Date.now()}-${crypto.randomInt(1000, 9999)}`
+
+  try {
+    logStep('Create tenant + warehouse + product + stock-level')
+    const tRes = await request('/tenants', {
+      method: 'POST',
+      headers: auth,
+      body: { name: `E2E MV Inv ${suffix}` },
+    })
+    assert(tRes.status === 200 || tRes.status === 201, `tenant create ${tRes.status}: ${tRes.text?.slice(0, 200)}`)
+    const tenantId = tRes.json?.doc?.id || tRes.json?.id
+    assert(tenantId, 'tenant id')
+
+    const locRes = await request('/stock-locations', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        name: `WH-${suffix}`,
+        code: `WH-${suffix}`,
+        tenant: tenantId,
+        isActive: true,
+      },
+    })
+    assert(locRes.status === 200 || locRes.status === 201, `stock-location ${locRes.status}: ${locRes.text?.slice(0, 200)}`)
+    const locationId = locRes.json?.doc?.id || locRes.json?.id
+    assert(locationId, 'location id')
+
+    const pRes = await request('/products', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        name: `E2E Product ${suffix}`,
+        basePrice: 10,
+        currency: 'USD',
+        status: 'published',
+        tenant: tenantId,
+      },
+    })
+    assert(pRes.status === 200 || pRes.status === 201, `product ${pRes.status}: ${pRes.text?.slice(0, 200)}`)
+    const productId = pRes.json?.doc?.id || pRes.json?.id
+    assert(productId, 'product id')
+
+    const slRes = await request('/stock-levels', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        product: productId,
+        location: locationId,
+        quantity: 100,
+        reservedQuantity: 0,
+      },
+    })
+    assert(slRes.status === 200 || slRes.status === 201, `stock-level ${slRes.status}: ${slRes.text?.slice(0, 200)}`)
+    const stockLevelId = slRes.json?.doc?.id || slRes.json?.id
+    assert(stockLevelId, 'stock level id')
+
+    // Guest cart must be created without Authorization: carts hooks only set guestId
+    // from X-Guest-Id when req.user is absent; admin-created carts get user=admin and
+    // checkout/process as guest then fails "Cart does not belong to this guest".
+    logStep('Guest cart + checkout')
+    const cartRes = await request('/carts', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': guestId },
+      body: { items: [{ product: productId, quantity: 1 }] },
+    })
+    assert(cartRes.status === 201, `cart ${cartRes.status}`)
+    const cartId = cartRes.json?.doc?.id || cartRes.json?.id
+    assert(cartId, 'cart id')
+
+    const coRes = await request('/checkout/process', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': guestId },
+      body: {
+        cartId,
+        guestEmail: `guest-${suffix}@example.com`,
+        simulatePayment: true,
+        shippingAddress: {
+          firstName: 'T',
+          lastName: 'G',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+        billingAddress: {
+          firstName: 'T',
+          lastName: 'G',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+      },
+    })
+    assert(coRes.status === 201, `checkout ${coRes.status}: ${coRes.text?.slice(0, 300)}`)
+    const orderId = coRes.json?.order?.id
+    assert(orderId, 'order id')
+    ok('checkout 201', `order=${orderId}`)
+
+    logStep('Verify order line has stockLevel')
+    const oiRes = await request(
+      `/order-items?where[order][equals]=${orderId}&limit=5&depth=1`,
+      { method: 'GET', headers: auth },
+    )
+    assert(oiRes.status === 200, `get order-items ${oiRes.status}`)
+    const docs = oiRes.json?.docs || []
+    assert(docs.length >= 1, 'expected at least one order-item')
+    const first = docs[0]
+    const slRef = first?.stockLevel
+    const slId = slRef && typeof slRef === 'object' ? slRef.id : slRef
+    assert(slId === stockLevelId, `expected stockLevel ${stockLevelId}, got ${JSON.stringify(slRef)}`)
+    ok('order-line stockLevel matches seeded stock-level')
+
+    logStep('Verify reservedQuantity increased on stock-level')
+    const slGet = await request(`/stock-levels/${stockLevelId}`, {
+      method: 'GET',
+      headers: auth,
+    })
+    assert(slGet.status === 200, `get stock-level ${slGet.status}`)
+    const reserved = Number(slGet.json?.reservedQuantity ?? 0)
+    assert(reserved >= 1, `expected reservedQuantity >= 1, got ${reserved}`)
+    ok('stock-level reservedQuantity >= 1')
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    fail('multivendor inventory checkout', msg)
+    console.error(e)
+    process.exit(1)
+  }
+
+  const failed = printSummary('Multivendor + inventory checkout')
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/backend/tests/e2e/inventory/inventory-allocation-reassign.e2e.test.mjs
+++ b/packages/backend/tests/e2e/inventory/inventory-allocation-reassign.e2e.test.mjs
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+/**
+ * Phase 12 — Multi-warehouse allocation + vendor stock reassignment (live API).
+ *
+ * When MULTIVENDOR_ENABLED=false:
+ *   - One product, two platform stock-locations / stock-levels with enough qty each.
+ *   - Checkout must allocate the row with the lexicographically smaller stock-level id
+ *     (same rule as allocate-stock-level.ts).
+ *
+ * When MULTIVENDOR_ENABLED=true:
+ *   - Approve a vendor, admin seeds two tenant warehouses + stock-levels + published product.
+ *   - Checkout: guest (if GUEST_CHECKOUT_ENABLED) or admin cart — assert deterministic pick (min stock-level id).
+ *   - Vendor PATCH order-items/{id} { stockLevel: otherRowId }: reservation moves (transfer hook).
+ *
+ * Requires: RUN_INTEGRATION_TESTS=true, ADMIN_TOKEN, INVENTORY_ENABLED=true.
+ * Skips with exit 0 when prerequisites missing.
+ */
+
+import crypto from 'node:crypto'
+import { createClient } from '../../_helpers/live-api-client.mjs'
+
+const { request, ok, fail, skip, logStep, printSummary } = createClient()
+const RUN = process.env.RUN_INTEGRATION_TESTS === 'true'
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN || null
+const mv = process.env.MULTIVENDOR_ENABLED === 'true'
+const inv = process.env.INVENTORY_ENABLED !== 'false'
+const guestCheckout = process.env.GUEST_CHECKOUT_ENABLED !== 'false'
+const AUTH_REQUIRED = (process.env.AUTH_REQUIRED_IDENTIFIER || 'either').toLowerCase()
+
+const auth = ADMIN_TOKEN ? { Authorization: `Bearer ${ADMIN_TOKEN}` } : {}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg)
+}
+
+function randomPhone() {
+  return `+1555${String(1000000000 + Math.floor(Math.random() * 8999999999))}`
+}
+
+function selectOrString(v) {
+  if (v == null) return ''
+  if (typeof v === 'string') return v
+  if (typeof v === 'object' && 'value' in v && v.value != null) return String(v.value)
+  return String(v)
+}
+
+function sleepMs(ms) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+/**
+ * Vendor user may have username = phone (phone-first). Try auth/login + users/login like test-data-manager.
+ */
+async function vendorLoginToken(email, password, phone) {
+  const attempts = []
+  if (phone) {
+    attempts.push(() =>
+      request('/auth/login', { method: 'POST', body: { identifier: phone, password } }),
+    )
+  }
+  attempts.push(() => request('/users/login', { method: 'POST', body: { email, password } }))
+  attempts.push(() =>
+    request('/auth/login', { method: 'POST', body: { identifier: email, password } }),
+  )
+  let last
+  for (const run of attempts) {
+    last = await run()
+    if (last.status === 200 && last.json?.token) return last.json.token
+  }
+  const hint = last?.text?.slice(0, 200) ?? ''
+  throw new Error(`vendor login failed (last status ${last?.status}) ${hint}`)
+}
+
+async function waitForVendorTenant(userId) {
+  for (let i = 0; i < 20; i++) {
+    const userGet = await request(`/users/${userId}?depth=1`, { headers: auth })
+    if (userGet.status === 200) {
+      const tenantRef = userGet.json?.tenant
+      const tid = tenantRef && typeof tenantRef === 'object' ? tenantRef.id : tenantRef
+      if (tid) return tid
+    }
+    await sleepMs(100)
+  }
+  return null
+}
+
+/** Lexicographically smaller stock-level id wins allocation when both can fulfill. */
+function expectedStockLevelId(a, b) {
+  return String(a).localeCompare(String(b)) <= 0 ? String(a) : String(b)
+}
+
+function otherStockLevelId(a, b) {
+  return String(a).localeCompare(String(b)) <= 0 ? String(b) : String(a)
+}
+
+function stockLevelIdFromItem(doc) {
+  const sl = doc?.stockLevel
+  if (!sl) return null
+  return typeof sl === 'object' ? sl.id : sl
+}
+
+async function getStockLevelDoc(id) {
+  const r = await request(`/stock-levels/${id}`, { headers: auth })
+  assert(r.status === 200, `stock-level get ${r.status}`)
+  return r.json
+}
+
+const addr = {
+  firstName: 'A',
+  lastName: 'B',
+  street1: '1 St',
+  city: 'Test',
+  country: 'US',
+}
+
+async function adminCheckout(productId, qty = 1) {
+  const cart = await request('/carts', {
+    method: 'POST',
+    headers: { ...auth },
+    body: { items: [{ product: productId, quantity: qty, unitPrice: 10 }] },
+  })
+  assert(cart.status === 200 || cart.status === 201, `cart ${cart.status}`)
+  const cartId = cart.json?.doc?.id || cart.json?.id
+  const co = await request('/checkout/process', {
+    method: 'POST',
+    headers: { ...auth },
+    body: {
+      cartId,
+      shippingAddress: addr,
+      billingAddress: addr,
+      simulatePayment: true,
+    },
+  })
+  assert(co.status === 200 || co.status === 201, `checkout ${co.status}: ${co.text?.slice(0, 250)}`)
+  return co.json?.order?.id
+}
+
+async function getFirstOrderItem(orderId) {
+  const oiRes = await request(`/order-items?where[order][equals]=${orderId}&limit=5&depth=1`, {
+    headers: auth,
+  })
+  assert(oiRes.status === 200, `order-items ${oiRes.status}`)
+  const docs = oiRes.json?.docs || []
+  assert(docs.length >= 1, 'expected order-item')
+  return docs[0]
+}
+
+async function testSingleVendorTwoWarehouses() {
+  const suffix = `${Date.now()}-${crypto.randomInt(1000, 9999)}`
+  logStep('SV: two platform warehouses — deterministic stock-level id')
+  const loc1 = await request('/stock-locations', {
+    method: 'POST',
+    headers: auth,
+    body: { name: `WH-A-${suffix}`, code: `WHA-${suffix}`, isActive: true },
+  })
+  const loc2 = await request('/stock-locations', {
+    method: 'POST',
+    headers: auth,
+    body: { name: `WH-B-${suffix}`, code: `WHB-${suffix}`, isActive: true },
+  })
+  assert(loc1.status === 200 || loc1.status === 201, `loc1 ${loc1.status}`)
+  assert(loc2.status === 200 || loc2.status === 201, `loc2 ${loc2.status}`)
+  const locId1 = loc1.json?.doc?.id || loc1.json?.id
+  const locId2 = loc2.json?.doc?.id || loc2.json?.id
+
+  const pRes = await request('/products', {
+    method: 'POST',
+    headers: auth,
+    body: {
+      name: `E2E 2WH ${suffix}`,
+      basePrice: 10,
+      currency: 'USD',
+      status: 'published',
+    },
+  })
+  assert(pRes.status === 200 || pRes.status === 201, `product ${pRes.status}`)
+  const productId = pRes.json?.doc?.id || pRes.json?.id
+
+  const sl1 = await request('/stock-levels', {
+    method: 'POST',
+    headers: auth,
+    body: { product: productId, location: locId1, quantity: 50, reservedQuantity: 0 },
+  })
+  const sl2 = await request('/stock-levels', {
+    method: 'POST',
+    headers: auth,
+    body: { product: productId, location: locId2, quantity: 50, reservedQuantity: 0 },
+  })
+  assert(sl1.status === 200 || sl1.status === 201, `sl1 ${sl1.status}`)
+  assert(sl2.status === 200 || sl2.status === 201, `sl2 ${sl2.status}`)
+  const id1 = sl1.json?.doc?.id || sl1.json?.id
+  const id2 = sl2.json?.doc?.id || sl2.json?.id
+  const expected = expectedStockLevelId(id1, id2)
+
+  const orderId = await adminCheckout(productId, 1)
+  assert(orderId, 'order id')
+  const item = await getFirstOrderItem(orderId)
+  const picked = stockLevelIdFromItem(item)
+  assert(picked === expected, `expected allocation ${expected}, got ${picked}`)
+  ok('SV: checkout picked lexicographically first eligible stock-level')
+}
+
+/**
+ * @param {{ useGuestCheckout: boolean }} opts
+ */
+async function testMultivendorPickAndVendorReassign(opts) {
+  const { useGuestCheckout } = opts
+  const suffix = `${Date.now()}-${crypto.randomInt(1000, 9999)}`
+  logStep(
+    useGuestCheckout
+      ? 'MV: vendor + two warehouses + guest checkout + vendor reassign stockLevel'
+      : 'MV: vendor + two warehouses + admin checkout + vendor reassign stockLevel (no guest)',
+  )
+
+  const vendorEmail = `e2e-reassign-${suffix}@test.local`
+  const vendorPassword = 'VendorReassign1234!'
+  const vendorPhone = AUTH_REQUIRED === 'phone' ? randomPhone() : null
+  const applicantBody = {
+    email: vendorEmail,
+    password: vendorPassword,
+    firstName: 'Re',
+    lastName: 'Assign',
+  }
+  if (vendorPhone) applicantBody.phone = vendorPhone
+
+  const uRes = await request('/users', { method: 'POST', body: applicantBody })
+  assert(uRes.status === 200 || uRes.status === 201, `vendor user ${uRes.status}: ${uRes.text?.slice(0, 200)}`)
+  const vendorUserId = uRes.json?.doc?.id || uRes.json?.id
+  assert(vendorUserId, 'vendor user id')
+
+  const verifyPatch = { emailVerified: true }
+  if (vendorPhone) verifyPatch.phoneVerified = true
+  const vPatch = await request(`/users/${vendorUserId}`, {
+    method: 'PATCH',
+    headers: auth,
+    body: verifyPatch,
+  })
+  assert(vPatch.status === 200, `vendor user verify flags ${vPatch.status}`)
+
+  const appRes = await request('/vendor-applications', {
+    method: 'POST',
+    headers: auth,
+    body: {
+      businessName: `E2E Reassign Co ${suffix}`,
+      businessType: 'individual',
+      applicant: vendorUserId,
+    },
+  })
+  assert(appRes.status === 200 || appRes.status === 201, `application ${appRes.status}`)
+  const appId = appRes.json?.doc?.id || appRes.json?.id
+  assert(appId, 'application id')
+
+  const appDoc = appRes.json?.doc || appRes.json
+  const initialStatus = selectOrString(appDoc?.status)
+  if (initialStatus !== 'approved') {
+    const approve = await request(`/vendor-applications/${appId}`, {
+      method: 'PATCH',
+      headers: auth,
+      body: { status: 'approved' },
+    })
+    assert(approve.status === 200, `approve ${approve.status}: ${approve.text?.slice(0, 200)}`)
+  }
+
+  const tenantId = await waitForVendorTenant(vendorUserId)
+  assert(tenantId, 'vendor tenant id (after application approved; hook may be briefly async)')
+
+  const pRes = await request('/products', {
+    method: 'POST',
+    headers: auth,
+    body: {
+      name: `E2E MV 2WH ${suffix}`,
+      basePrice: 10,
+      currency: 'USD',
+      status: 'published',
+      tenant: tenantId,
+    },
+  })
+  assert(pRes.status === 200 || pRes.status === 201, `product ${pRes.status}`)
+  const productId = pRes.json?.doc?.id || pRes.json?.id
+
+  const loc1 = await request('/stock-locations', {
+    method: 'POST',
+    headers: auth,
+    body: { name: `MV-W1-${suffix}`, code: `MVW1-${suffix}`, tenant: tenantId, isActive: true },
+  })
+  const loc2 = await request('/stock-locations', {
+    method: 'POST',
+    headers: auth,
+    body: { name: `MV-W2-${suffix}`, code: `MVW2-${suffix}`, tenant: tenantId, isActive: true },
+  })
+  assert(loc1.status === 200 || loc1.status === 201, `mv loc1 ${loc1.status}`)
+  assert(loc2.status === 200 || loc2.status === 201, `mv loc2 ${loc2.status}`)
+  const locId1 = loc1.json?.doc?.id || loc1.json?.id
+  const locId2 = loc2.json?.doc?.id || loc2.json?.id
+
+  const sl1 = await request('/stock-levels', {
+    method: 'POST',
+    headers: auth,
+    body: { product: productId, location: locId1, quantity: 50, reservedQuantity: 0 },
+  })
+  const sl2 = await request('/stock-levels', {
+    method: 'POST',
+    headers: auth,
+    body: { product: productId, location: locId2, quantity: 50, reservedQuantity: 0 },
+  })
+  assert(sl1.status === 200 || sl1.status === 201, `mv sl1 ${sl1.status}`)
+  assert(sl2.status === 200 || sl2.status === 201, `mv sl2 ${sl2.status}`)
+  const stockId1 = sl1.json?.doc?.id || sl1.json?.id
+  const stockId2 = sl2.json?.doc?.id || sl2.json?.id
+  const expectedPick = expectedStockLevelId(stockId1, stockId2)
+  const alternateId = otherStockLevelId(stockId1, stockId2)
+
+  let orderId
+  if (useGuestCheckout) {
+    const guestId = crypto.randomUUID()
+    const cartRes = await request('/carts', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': guestId },
+      body: { items: [{ product: productId, quantity: 1 }] },
+    })
+    assert(cartRes.status === 201, `guest cart ${cartRes.status}`)
+    const cartId = cartRes.json?.doc?.id || cartRes.json?.id
+
+    const coRes = await request('/checkout/process', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': guestId },
+      body: {
+        cartId,
+        guestEmail: `guest-${suffix}@example.com`,
+        simulatePayment: true,
+        shippingAddress: {
+          firstName: 'G',
+          lastName: 'uest',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+        billingAddress: {
+          firstName: 'G',
+          lastName: 'uest',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+      },
+    })
+    assert(coRes.status === 201, `guest checkout ${coRes.status}: ${coRes.text?.slice(0, 250)}`)
+    orderId = coRes.json?.order?.id
+  } else {
+    orderId = await adminCheckout(productId, 1)
+  }
+  assert(orderId, 'order id')
+
+  const item = await getFirstOrderItem(orderId)
+  const itemId = item.id
+  const picked = stockLevelIdFromItem(item)
+  assert(picked === expectedPick, `expected pick ${expectedPick}, got ${picked}`)
+  ok(
+    useGuestCheckout
+      ? 'MV: guest checkout picked lexicographically first eligible stock-level'
+      : 'MV: admin checkout picked lexicographically first eligible stock-level',
+  )
+
+  const beforeFrom = await getStockLevelDoc(expectedPick)
+  const beforeTo = await getStockLevelDoc(alternateId)
+  const rFrom = Number(beforeFrom.reservedQuantity ?? 0)
+  const rTo = Number(beforeTo.reservedQuantity ?? 0)
+  assert(rFrom >= 1, `expected reservation on picked row >= 1, got ${rFrom}`)
+  assert(rTo === 0, `expected no reservation on alternate row, got ${rTo}`)
+
+  const vendorToken = await vendorLoginToken(vendorEmail, vendorPassword, vendorPhone)
+  const vendorAuth = { Authorization: `Bearer ${vendorToken}` }
+
+  const patchRes = await request(`/order-items/${itemId}`, {
+    method: 'PATCH',
+    headers: vendorAuth,
+    body: { stockLevel: alternateId },
+  })
+  assert(patchRes.status === 200, `vendor patch stockLevel ${patchRes.status}: ${patchRes.text?.slice(0, 250)}`)
+
+  const afterFrom = await getStockLevelDoc(expectedPick)
+  const afterTo = await getStockLevelDoc(alternateId)
+  const rFrom2 = Number(afterFrom.reservedQuantity ?? 0)
+  const rTo2 = Number(afterTo.reservedQuantity ?? 0)
+  assert(rFrom2 === rFrom - 1, `picked row reserved: expected ${rFrom - 1}, got ${rFrom2}`)
+  assert(rTo2 === rTo + 1, `alternate row reserved: expected ${rTo + 1}, got ${rTo2}`)
+  ok('MV: vendor PATCH stockLevel moved reservation to other warehouse')
+}
+
+async function main() {
+  console.log('inventory-allocation-reassign E2E | MV=' + mv + ' | INV=' + inv + ' | guest=' + guestCheckout)
+
+  if (!RUN || !ADMIN_TOKEN) {
+    skip('allocation/reassign', 'requires RUN_INTEGRATION_TESTS, ADMIN_TOKEN')
+    printSummary('Inventory allocation & vendor reassign E2E')
+    process.exit(0)
+  }
+
+  if (!inv) {
+    skip('allocation/reassign', 'INVENTORY_ENABLED=false')
+    printSummary('Inventory allocation & vendor reassign E2E')
+    process.exit(0)
+  }
+
+  const checkMv = await request('/vendor-applications?limit=0', { headers: auth })
+  if (mv && checkMv.status === 404) {
+    skip('allocation/reassign', 'MULTIVENDOR_ENABLED in env but vendor-applications missing')
+    printSummary('Inventory allocation & vendor reassign E2E')
+    process.exit(0)
+  }
+
+  try {
+    if (!mv) {
+      await testSingleVendorTwoWarehouses()
+    } else {
+      await testMultivendorPickAndVendorReassign({ useGuestCheckout: guestCheckout })
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    fail('inventory allocation/reassign', msg)
+    console.error(e)
+    printSummary('Inventory allocation & vendor reassign E2E')
+    process.exit(1)
+  }
+
+  const failed = printSummary('Inventory allocation & vendor reassign E2E')
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/backend/tests/e2e/inventory/inventory-lifecycle.e2e.test.mjs
+++ b/packages/backend/tests/e2e/inventory/inventory-lifecycle.e2e.test.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Single-vendor + inventory E2E (Phase 12 business paths).
+ *
+ * Covers:
+ * - Checkout persists order-items.stockLevel and increases reservedQuantity
+ * - Order cancel (before ship) releases reservation
+ * - Order shipped consumes physical qty + reserved (admin checkout path)
+ * - Checkout returns 400 when no single warehouse can fulfill line qty (insufficient stock)
+ *
+ * Skips with exit 0 when INVENTORY_ENABLED=false, MULTIVENDOR_ENABLED=true (MV inventory:
+ * multivendor-inventory-checkout + multivendor-inventory-lifecycle), or missing tokens.
+ */
+
+import crypto from 'node:crypto'
+import { createClient } from '../../_helpers/live-api-client.mjs'
+
+const { request, ok, fail, skip, logStep, printSummary } = createClient()
+const RUN = process.env.RUN_INTEGRATION_TESTS === 'true'
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN || null
+const PRODUCT_ID = process.env.PRODUCT_ID || null
+const mv = process.env.MULTIVENDOR_ENABLED === 'true'
+const inv = process.env.INVENTORY_ENABLED !== 'false'
+
+const auth = ADMIN_TOKEN ? { Authorization: `Bearer ${ADMIN_TOKEN}` } : {}
+const addr = {
+  firstName: 'Inv',
+  lastName: 'Test',
+  street1: '1 Warehouse Rd',
+  city: 'Test',
+  country: 'US',
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg)
+}
+
+function stockLevelIdFromItem(doc) {
+  const sl = doc?.stockLevel
+  if (!sl) return null
+  return typeof sl === 'object' ? sl.id : sl
+}
+
+async function adminCheckout(productId, qty = 1) {
+  const cart = await request('/carts', {
+    method: 'POST',
+    headers: { ...auth },
+    body: { items: [{ product: productId, quantity: qty, unitPrice: 99 }] },
+  })
+  assert(cart.status === 200 || cart.status === 201, `cart ${cart.status}: ${cart.text?.slice(0, 200)}`)
+  const cartId = cart.json?.doc?.id || cart.json?.id
+  assert(cartId, 'cart id')
+  const co = await request('/checkout/process', {
+    method: 'POST',
+    headers: { ...auth },
+    body: {
+      cartId,
+      shippingAddress: addr,
+      billingAddress: addr,
+      simulatePayment: true,
+    },
+  })
+  assert(co.status === 200 || co.status === 201, `checkout ${co.status}: ${co.text?.slice(0, 300)}`)
+  const orderId = co.json?.order?.id
+  assert(orderId, 'order id')
+  return orderId
+}
+
+async function getFirstOrderItem(orderId) {
+  const oiRes = await request(`/order-items?where[order][equals]=${orderId}&limit=5&depth=1`, {
+    headers: { ...auth },
+  })
+  assert(oiRes.status === 200, `order-items ${oiRes.status}`)
+  const docs = oiRes.json?.docs || []
+  assert(docs.length >= 1, 'expected order-item')
+  return docs[0]
+}
+
+async function getStockLevelDoc(id) {
+  const r = await request(`/stock-levels/${id}`, { headers: { ...auth } })
+  assert(r.status === 200, `stock-level get ${r.status}`)
+  return r.json
+}
+
+async function main() {
+  console.log('inventory-lifecycle E2E | MV=' + mv + ' | INV=' + inv)
+
+  if (!RUN || !ADMIN_TOKEN || !PRODUCT_ID) {
+    skip('inventory lifecycle', 'requires RUN_INTEGRATION_TESTS, ADMIN_TOKEN, PRODUCT_ID')
+    printSummary('Inventory lifecycle E2E')
+    process.exit(0)
+  }
+
+  if (!inv) {
+    console.log('SKIP: INVENTORY_ENABLED=false')
+    printSummary('Inventory lifecycle E2E')
+    process.exit(0)
+  }
+
+  if (mv) {
+    console.log('SKIP: MULTIVENDOR_ENABLED=true (see tests/e2e/inventory/multivendor-inventory-lifecycle.e2e.test.mjs)')
+    printSummary('Inventory lifecycle E2E')
+    process.exit(0)
+  }
+
+  try {
+    logStep('Checkout: order line has stockLevel + reserved increases')
+    const order1 = await adminCheckout(PRODUCT_ID, 1)
+    const item1 = await getFirstOrderItem(order1)
+    const slId = stockLevelIdFromItem(item1)
+    assert(slId, 'order-item missing stockLevel')
+    ok('order-item has stockLevel', String(slId))
+
+    const afterReserve = await getStockLevelDoc(slId)
+    const r1 = Number(afterReserve.reservedQuantity ?? 0)
+    const q1 = Number(afterReserve.quantity ?? 0)
+    assert(r1 >= 1, `expected reservedQuantity >= 1 after checkout, got ${r1}`)
+    ok('reservedQuantity after checkout', String(r1))
+
+    logStep('Cancel order: reservation released')
+    const cancel = await request(`/orders/${order1}`, {
+      method: 'PATCH',
+      headers: { ...auth },
+      body: { status: 'cancelled' },
+    })
+    assert(cancel.status === 200, `cancel ${cancel.status}: ${cancel.text?.slice(0, 200)}`)
+    const afterCancel = await getStockLevelDoc(slId)
+    const r2 = Number(afterCancel.reservedQuantity ?? 0)
+    assert(r2 === r1 - 1, `expected reserved ${r1 - 1} after cancel, got ${r2}`)
+    ok('reservedQuantity after cancel', String(r2))
+
+    logStep('Second checkout + ship: consume qty and reserved')
+    const order2 = await adminCheckout(PRODUCT_ID, 1)
+    const item2 = await getFirstOrderItem(order2)
+    assert(stockLevelIdFromItem(item2) === slId, 'same stock level row for seeded product')
+    const beforeShip = await getStockLevelDoc(slId)
+    const r3 = Number(beforeShip.reservedQuantity ?? 0)
+    const q3 = Number(beforeShip.quantity ?? 0)
+    assert(r3 >= 1, `expected reserved before ship >= 1, got ${r3}`)
+
+    const ship = await request(`/orders/${order2}`, {
+      method: 'PATCH',
+      headers: { ...auth },
+      body: { status: 'shipped' },
+    })
+    assert(ship.status === 200, `ship ${ship.status}: ${ship.text?.slice(0, 200)}`)
+    const afterShip = await getStockLevelDoc(slId)
+    const r4 = Number(afterShip.reservedQuantity ?? 0)
+    const q4 = Number(afterShip.quantity ?? 0)
+    assert(r4 === r3 - 1, `expected reserved ${r3 - 1} after ship, got ${r4}`)
+    assert(q4 === q3 - 1, `expected quantity ${q3 - 1} after consume, got ${q4}`)
+    ok('consume on ship: quantity and reserved decreased')
+
+    logStep('Insufficient stock: checkout should fail')
+    const suffix = `${Date.now()}-${crypto.randomInt(1000, 9999)}`
+    const pRes = await request('/products', {
+      method: 'POST',
+      headers: { ...auth },
+      body: {
+        name: `E2E Low Stock ${suffix}`,
+        basePrice: 5,
+        currency: 'USD',
+        status: 'published',
+      },
+    })
+    assert(pRes.status === 200 || pRes.status === 201, `product ${pRes.status}`)
+    const lowPid = pRes.json?.doc?.id || pRes.json?.id
+    assert(lowPid, 'low product id')
+
+    const locRes = await request('/stock-locations', {
+      method: 'POST',
+      headers: { ...auth },
+      body: { name: `Loc-${suffix}`, code: `LOC-${suffix}`, isActive: true },
+    })
+    assert(locRes.status === 200 || locRes.status === 201, `location ${locRes.status}`)
+    const locId = locRes.json?.doc?.id || locRes.json?.id
+
+    const slLow = await request('/stock-levels', {
+      method: 'POST',
+      headers: { ...auth },
+      body: {
+        product: lowPid,
+        location: locId,
+        quantity: 2,
+        reservedQuantity: 0,
+      },
+    })
+    assert(slLow.status === 200 || slLow.status === 201, `stock-level ${slLow.status}`)
+
+    const badCart = await request('/carts', {
+      method: 'POST',
+      headers: { ...auth },
+      body: { items: [{ product: lowPid, quantity: 50, unitPrice: 5 }] },
+    })
+    assert(badCart.status === 200 || badCart.status === 201, `bad cart ${badCart.status}`)
+    const badCartId = badCart.json?.doc?.id || badCart.json?.id
+    const badCo = await request('/checkout/process', {
+      method: 'POST',
+      headers: { ...auth },
+      body: {
+        cartId: badCartId,
+        shippingAddress: addr,
+        billingAddress: addr,
+        simulatePayment: true,
+      },
+    })
+    assert(badCo.status === 400, `expected 400 insufficient stock, got ${badCo.status}`)
+    assert(
+      String(badCo.text || '').toLowerCase().includes('stock') ||
+        String(badCo.text || '').toLowerCase().includes('warehouse'),
+      'error body should mention stock/warehouse',
+    )
+    ok('checkout 400 when stock cannot fulfill line')
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    fail('inventory lifecycle', msg)
+    console.error(e)
+    printSummary('Inventory lifecycle E2E')
+    process.exit(1)
+  }
+
+  const failed = printSummary('Inventory lifecycle E2E')
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/backend/tests/e2e/inventory/multivendor-inventory-lifecycle.e2e.test.mjs
+++ b/packages/backend/tests/e2e/inventory/multivendor-inventory-lifecycle.e2e.test.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+/**
+ * Multivendor + inventory E2E: release/consume run on **sub-orders** (not parent orders).
+ *
+ * Covers:
+ * - Guest checkout → order-items.stockLevel + reservedQuantity (sanity with existing MV checkout)
+ * - PATCH sub-order cancelled → reservation released (releaseOrderInventory on sub-order items)
+ * - Second guest checkout → sub-order processing → shipped → quantity + reservedQuantity consumed
+ * - Guest checkout 400 when line qty exceeds single-warehouse availability
+ *
+ * Requires: MULTIVENDOR_ENABLED=true, INVENTORY_ENABLED=true, GUEST_CHECKOUT_ENABLED=true, ADMIN_TOKEN.
+ * Skips exit 0 when flags/env not met.
+ */
+
+import crypto from 'node:crypto'
+import { createClient } from '../../_helpers/live-api-client.mjs'
+
+const { request, ok, fail, skip, logStep, printSummary } = createClient()
+const mv = process.env.MULTIVENDOR_ENABLED === 'true'
+const inv = process.env.INVENTORY_ENABLED !== 'false'
+const guestCheckout = process.env.GUEST_CHECKOUT_ENABLED !== 'false'
+const RUN = process.env.RUN_INTEGRATION_TESTS === 'true'
+const token = process.env.ADMIN_TOKEN
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg)
+}
+
+function stockLevelIdFromItem(doc) {
+  const sl = doc?.stockLevel
+  if (!sl) return null
+  return typeof sl === 'object' ? sl.id : sl
+}
+
+async function main() {
+  console.log('multivendor-inventory-lifecycle E2E | MV=' + mv + ' | INV=' + inv)
+
+  if (!RUN) {
+    skip('mv inventory lifecycle', 'requires RUN_INTEGRATION_TESTS=true')
+    printSummary('Multivendor inventory lifecycle E2E')
+    process.exit(0)
+  }
+
+  if (!mv || !inv) {
+    skip('mv inventory lifecycle', 'requires MULTIVENDOR_ENABLED=true and INVENTORY_ENABLED=true')
+    printSummary('Multivendor inventory lifecycle E2E')
+    process.exit(0)
+  }
+
+  if (!guestCheckout) {
+    skip('mv inventory lifecycle', 'requires GUEST_CHECKOUT_ENABLED=true')
+    printSummary('Multivendor inventory lifecycle E2E')
+    process.exit(0)
+  }
+
+  if (!token) {
+    console.error('FAIL: ADMIN_TOKEN missing (run via tests/run-e2e.mjs)')
+    process.exit(1)
+  }
+
+  const auth = { Authorization: `Bearer ${token}` }
+  const suffix = `${Date.now()}-${crypto.randomInt(1000, 9999)}`
+
+  async function seedTenantProductStock(tag = suffix) {
+    const tRes = await request('/tenants', {
+      method: 'POST',
+      headers: auth,
+      body: { name: `E2E MV Inv LC ${tag}` },
+    })
+    assert(tRes.status === 200 || tRes.status === 201, `tenant ${tRes.status}: ${tRes.text?.slice(0, 200)}`)
+    const tenantId = tRes.json?.doc?.id || tRes.json?.id
+    assert(tenantId, 'tenant id')
+
+    const locRes = await request('/stock-locations', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        name: `WH-LC-${tag}`,
+        code: `WH-LC-${tag}`,
+        tenant: tenantId,
+        isActive: true,
+      },
+    })
+    assert(locRes.status === 200 || locRes.status === 201, `stock-location ${locRes.status}`)
+    const locationId = locRes.json?.doc?.id || locRes.json?.id
+    assert(locationId, 'location id')
+
+    const pRes = await request('/products', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        name: `E2E MV LC Product ${tag}`,
+        basePrice: 10,
+        currency: 'USD',
+        status: 'published',
+        tenant: tenantId,
+      },
+    })
+    assert(pRes.status === 200 || pRes.status === 201, `product ${pRes.status}`)
+    const productId = pRes.json?.doc?.id || pRes.json?.id
+    assert(productId, 'product id')
+
+    const slRes = await request('/stock-levels', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        product: productId,
+        location: locationId,
+        quantity: 100,
+        reservedQuantity: 0,
+      },
+    })
+    assert(slRes.status === 200 || slRes.status === 201, `stock-level ${slRes.status}`)
+    const stockLevelId = slRes.json?.doc?.id || slRes.json?.id
+    assert(stockLevelId, 'stock level id')
+
+    return { tenantId, productId, stockLevelId }
+  }
+
+  async function guestCheckoutProduct(productId, guestId) {
+    const cartRes = await request('/carts', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': guestId },
+      body: { items: [{ product: productId, quantity: 1 }] },
+    })
+    assert(cartRes.status === 201, `cart ${cartRes.status}`)
+    const cartId = cartRes.json?.doc?.id || cartRes.json?.id
+    assert(cartId, 'cart id')
+
+    const coRes = await request('/checkout/process', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': guestId },
+      body: {
+        cartId,
+        guestEmail: `guest-${guestId.slice(0, 8)}@example.com`,
+        simulatePayment: true,
+        shippingAddress: {
+          firstName: 'T',
+          lastName: 'G',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+        billingAddress: {
+          firstName: 'T',
+          lastName: 'G',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+      },
+    })
+    assert(coRes.status === 201, `checkout ${coRes.status}: ${coRes.text?.slice(0, 300)}`)
+    const orderId = coRes.json?.order?.id
+    assert(orderId, 'order id')
+    return orderId
+  }
+
+  async function getSubOrderForParent(parentOrderId) {
+    const soRes = await request(
+      `/sub-orders?where[parentOrder][equals]=${parentOrderId}&limit=10&depth=0`,
+      { method: 'GET', headers: auth },
+    )
+    assert(soRes.status === 200, `sub-orders list ${soRes.status}`)
+    const docs = soRes.json?.docs || []
+    assert(docs.length >= 1, 'expected at least one sub-order')
+    return docs[0].id
+  }
+
+  async function getFirstOrderItemForOrder(orderId) {
+    const oiRes = await request(
+      `/order-items?where[order][equals]=${orderId}&limit=5&depth=1`,
+      { method: 'GET', headers: auth },
+    )
+    assert(oiRes.status === 200, `order-items ${oiRes.status}`)
+    const docs = oiRes.json?.docs || []
+    assert(docs.length >= 1, 'expected order-item')
+    return docs[0]
+  }
+
+  async function getStockLevelDoc(id) {
+    const r = await request(`/stock-levels/${id}`, { headers: auth })
+    assert(r.status === 200, `stock-level ${r.status}`)
+    return r.json
+  }
+
+  try {
+    logStep('Seed tenant, product, stock')
+    const { productId, stockLevelId } = await seedTenantProductStock()
+
+    logStep('Guest checkout → line stockLevel + reserved')
+    const guest1 = crypto.randomUUID()
+    const order1 = await guestCheckoutProduct(productId, guest1)
+    const item1 = await getFirstOrderItemForOrder(order1)
+    assert(stockLevelIdFromItem(item1) === stockLevelId, 'order-item.stockLevel matches seeded row')
+    ok('MV line has stockLevel')
+
+    const afterReserve = await getStockLevelDoc(stockLevelId)
+    const r1 = Number(afterReserve.reservedQuantity ?? 0)
+    assert(r1 >= 1, `reserved >= 1, got ${r1}`)
+    ok('reserved after checkout', String(r1))
+
+    logStep('Cancel sub-order → reservation released')
+    const sub1 = await getSubOrderForParent(order1)
+    const cancelSo = await request(`/sub-orders/${sub1}`, {
+      method: 'PATCH',
+      headers: auth,
+      body: { status: 'cancelled' },
+    })
+    assert(cancelSo.status === 200, `sub-order cancel ${cancelSo.status}: ${cancelSo.text?.slice(0, 200)}`)
+    const afterCancel = await getStockLevelDoc(stockLevelId)
+    const r2 = Number(afterCancel.reservedQuantity ?? 0)
+    assert(r2 === r1 - 1, `expected reserved ${r1 - 1} after sub-order cancel, got ${r2}`)
+    ok('reserved after sub-order cancel', String(r2))
+
+    logStep('Second guest checkout → sub-order processing → shipped → consume')
+    const guest2 = crypto.randomUUID()
+    const order2 = await guestCheckoutProduct(productId, guest2)
+    await getFirstOrderItemForOrder(order2)
+    const sub2 = await getSubOrderForParent(order2)
+    const beforeShip = await getStockLevelDoc(stockLevelId)
+    const r3 = Number(beforeShip.reservedQuantity ?? 0)
+    const q3 = Number(beforeShip.quantity ?? 0)
+    assert(r3 >= 1, `reserved before ship >= 1, got ${r3}`)
+
+    const proc = await request(`/sub-orders/${sub2}`, {
+      method: 'PATCH',
+      headers: auth,
+      body: { status: 'processing' },
+    })
+    assert(proc.status === 200, `sub-order processing ${proc.status}: ${proc.text?.slice(0, 200)}`)
+
+    const ship = await request(`/sub-orders/${sub2}`, {
+      method: 'PATCH',
+      headers: auth,
+      body: { status: 'shipped' },
+    })
+    assert(ship.status === 200, `sub-order ship ${ship.status}: ${ship.text?.slice(0, 200)}`)
+
+    const afterShip = await getStockLevelDoc(stockLevelId)
+    const r4 = Number(afterShip.reservedQuantity ?? 0)
+    const q4 = Number(afterShip.quantity ?? 0)
+    assert(r4 === r3 - 1, `expected reserved ${r3 - 1} after ship, got ${r4}`)
+    assert(q4 === q3 - 1, `expected quantity ${q3 - 1} after consume, got ${q4}`)
+    ok('sub-order shipped: quantity and reserved decreased')
+
+    logStep('Insufficient stock: guest checkout 400')
+    const lowTag = `${Date.now()}-${crypto.randomInt(1000, 9999)}`
+    const tLow = await request('/tenants', {
+      method: 'POST',
+      headers: auth,
+      body: { name: `E2E MV Low tenant ${lowTag}` },
+    })
+    assert(tLow.status === 200 || tLow.status === 201, `low tenant ${tLow.status}`)
+    const lowTenantId = tLow.json?.doc?.id || tLow.json?.id
+    assert(lowTenantId, 'low tenant id')
+
+    const locLow = await request('/stock-locations', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        name: `LOC-${lowTag}`,
+        code: `LOC-${lowTag}`,
+        tenant: lowTenantId,
+        isActive: true,
+      },
+    })
+    assert(locLow.status === 200 || locLow.status === 201, `loc ${locLow.status}`)
+    const lowLocId = locLow.json?.doc?.id || locLow.json?.id
+
+    const pLow = await request('/products', {
+      method: 'POST',
+      headers: auth,
+      body: {
+        name: `E2E MV Low ${lowTag}`,
+        basePrice: 1,
+        currency: 'USD',
+        status: 'published',
+        tenant: lowTenantId,
+      },
+    })
+    assert(pLow.status === 200 || pLow.status === 201, `low product ${pLow.status}`)
+    const lowPid = pLow.json?.doc?.id || pLow.json?.id
+
+    const slLow = await request('/stock-levels', {
+      method: 'POST',
+      headers: auth,
+      body: { product: lowPid, location: lowLocId, quantity: 2, reservedQuantity: 0 },
+    })
+    assert(slLow.status === 200 || slLow.status === 201, `low stock-level ${slLow.status}`)
+
+    const g3 = crypto.randomUUID()
+    const cartBad = await request('/carts', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': g3 },
+      body: { items: [{ product: lowPid, quantity: 50 }] },
+    })
+    assert(cartBad.status === 201, `bad cart ${cartBad.status}`)
+    const badCartId = cartBad.json?.doc?.id || cartBad.json?.id
+
+    const badCo = await request('/checkout/process', {
+      method: 'POST',
+      headers: { 'X-Guest-Id': g3 },
+      body: {
+        cartId: badCartId,
+        guestEmail: `bad-${g3.slice(0, 8)}@example.com`,
+        simulatePayment: true,
+        shippingAddress: {
+          firstName: 'T',
+          lastName: 'G',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+        billingAddress: {
+          firstName: 'T',
+          lastName: 'G',
+          street1: '1 St',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+      },
+    })
+    assert(badCo.status === 400, `expected 400, got ${badCo.status}`)
+    const low = String(badCo.text || '').toLowerCase()
+    assert(low.includes('stock') || low.includes('warehouse'), 'body should mention stock/warehouse')
+    ok('MV guest checkout 400 when stock insufficient')
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    fail('multivendor inventory lifecycle', msg)
+    console.error(e)
+    printSummary('Multivendor inventory lifecycle E2E')
+    process.exit(1)
+  }
+
+  const failed = printSummary('Multivendor inventory lifecycle E2E')
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/backend/tests/env-profiles/README.md
+++ b/packages/backend/tests/env-profiles/README.md
@@ -2,7 +2,7 @@
 
 This directory contains all test environment configuration files for E2E testing.
 
-**Verification (baseline):** A full **`yarn test:all-profiles:safe:parallel:observe`** run (from `packages/backend`) executes the **safe** E2E path (`tests/run-e2e-safe.mjs`) once per profile—parallel batches with isolated slots—and aggregates results. (Sequential equivalent: `yarn test:all-profiles:safe`.) As of **2026-04-02**, all listed profiles passed (212 suite passes total across 12 profiles). Authoritative numbers and interpretation: **`docs/PHASE-9-TEST-COVERAGE-PLAN.md`** § *Verification record*.
+**Verification (baseline):** A full **`yarn test:all-profiles:safe:parallel:observe`** run (from `packages/backend`) executes the **safe** E2E path (`tests/run-e2e-safe.mjs`) once per profile—parallel batches with isolated slots—and aggregates results. (Sequential equivalent: `yarn test:all-profiles:safe`.) Per-profile suite counts differ slightly (e.g. `verify-off-gate-on` runs fewer steps); the matrix **Final Summary** should show **PASS** for every profile when green. Authoritative numbers and interpretation: **`docs/PHASE-9-TEST-COVERAGE-PLAN.md`** § *Verification record*.
 
 **Reference:** See `docs/ENV-REGISTRY.md` for complete variable documentation.
 
@@ -132,6 +132,46 @@ No gaps remaining in pairwise coverage.
 
 ---
 
+## Developer guide: Inventory (Phase 12)
+
+Use this when **`MULTIVENDOR_ENABLED=true`** and **`INVENTORY_ENABLED=true`** (warehouse rows, `order-items.stockLevel`, reserve/consume).
+
+**Unit and security (no server):**
+
+```bash
+cd packages/backend
+yarn test:unit
+# Focused:
+node --test --experimental-strip-types --import ./tests/_helpers/register-ts-resolve.mjs \
+  tests/unit/lib/allocate-stock-level.unit.test.ts \
+  tests/unit/checkout/process-checkout.unit.test.ts \
+  tests/security/inventory/allocate-stock-multivendor.security.test.ts
+```
+
+**E2E (server must match profile):**
+
+With `INVENTORY_ENABLED` on, **`tests/_helpers/test-data-manager.mjs`** `createProduct()` creates a **stock-location + stock-level** for that product so checkout allocation (Phase 12) succeeds — no changes to `run-e2e.mjs` or matrix runners are required.
+
+- Full safe path: `yarn test:e2e:safe -- --profile multivendor` (or `yarn test:e2e:safe:profile -- --profile multivendor`)
+- Checkout + inventory script runs as part of the normal guest/checkout suite when `suite` includes it.
+
+**Parallel matrix (many profiles at once, isolated slots/ports):**
+
+```bash
+yarn test:all-profiles:safe:parallel:observe
+# Subset of profiles (yarn forwards args after `--`; last `--max-parallel=` wins):
+yarn test:matrix:e2e:parallel -- --profiles=default,multivendor --max-parallel=2 --slot-start=0
+```
+
+**Sequential matrix (one profile at a time, same port):**
+
+```bash
+yarn test:all-profiles:safe
+node tests/run-all-profiles-safe.mjs --profiles=multivendor,gates-on
+```
+
+---
+
 ## Usage
 
 ```bash
@@ -139,7 +179,7 @@ No gaps remaining in pairwise coverage.
 node tests/run-e2e.mjs --profile multivendor
 
 # Safe local run (recommended)
-yarn test:e2e:safe --profile multivendor
+yarn test:e2e:safe -- --profile multivendor
 
 # Run specific suite with profile
 node tests/run-e2e.mjs --profile gates-on --suite auth

--- a/packages/backend/tests/run-all-profiles-safe-parallel-observe.mjs
+++ b/packages/backend/tests/run-all-profiles-safe-parallel-observe.mjs
@@ -27,7 +27,8 @@ const logsDir = path.join(backendRoot, 'tests', 'logs')
 fs.mkdirSync(logsDir, { recursive: true })
 
 function parseProfilesArg(allProfiles, args) {
-  const profilesArg = args.find((a) => a.startsWith('--profiles='))
+  const matches = args.filter((a) => a.startsWith('--profiles='))
+  const profilesArg = matches[matches.length - 1]
   if (!profilesArg) return allProfiles
   return profilesArg
     .replace('--profiles=', '')
@@ -36,8 +37,10 @@ function parseProfilesArg(allProfiles, args) {
     .filter(Boolean)
 }
 
+/** Last `--name=value` wins so `yarn script -- --max-parallel=1` overrides package.json defaults. */
 function parseNumberArg(args, name, fallback) {
-  const v = args.find((a) => a.startsWith(`${name}=`))
+  const matches = args.filter((a) => a.startsWith(`${name}=`))
+  const v = matches[matches.length - 1]
   if (!v) return fallback
   const parsed = Number(v.split('=')[1])
   return Number.isFinite(parsed) ? parsed : fallback
@@ -172,7 +175,7 @@ function runProfile(profile, slot, { postgresPort, redisPort, backendPort }) {
         exitCode: code ?? 1,
         passed,
         total,
-        success: (code ?? 1) === 0 && passed === total,
+        success: (code ?? 1) === 0 && total > 0 && passed === total,
         logPath,
       })
     })

--- a/packages/backend/tests/run-e2e.mjs
+++ b/packages/backend/tests/run-e2e.mjs
@@ -177,6 +177,10 @@ async function main() {
       run('Guest checkout', 'tests/e2e/checkout/guest-checkout.e2e.test.mjs', sharedEnv),
       run('Authenticated checkout', 'tests/e2e/checkout/authenticated-checkout.e2e.test.mjs', sharedEnv),
       run('Checkout security', 'tests/e2e/checkout/checkout-security.e2e.test.mjs', sharedEnv),
+      run('Multivendor inventory checkout', 'tests/e2e/checkout/multivendor-inventory-checkout.e2e.test.mjs', sharedEnv),
+      run('Multivendor inventory lifecycle', 'tests/e2e/inventory/multivendor-inventory-lifecycle.e2e.test.mjs', sharedEnv),
+      run('Inventory lifecycle', 'tests/e2e/inventory/inventory-lifecycle.e2e.test.mjs', sharedEnv),
+      run('Inventory allocation & vendor reassign', 'tests/e2e/inventory/inventory-allocation-reassign.e2e.test.mjs', sharedEnv),
     )
   }
 

--- a/packages/backend/tests/security/inventory/allocate-stock-multivendor.security.test.ts
+++ b/packages/backend/tests/security/inventory/allocate-stock-multivendor.security.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Phase 12: vendor A's catalog must not allocate from vendor B's warehouse rows.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { allocateStockLevelForLine } from '../../../src/lib/allocate-stock-level.ts'
+
+test('should not allocate tenant product from another tenant warehouse even if first by id', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'true'
+
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'aaa-first',
+          product: 'p1',
+          variant: null,
+          quantity: 500,
+          reservedQuantity: 0,
+          location: { tenant: { id: 'tenant-B' } },
+        },
+        {
+          id: 'zzz-second',
+          product: 'p1',
+          variant: null,
+          quantity: 10,
+          reservedQuantity: 0,
+          location: { tenant: { id: 'tenant-A' } },
+        },
+      ],
+    }),
+  }
+
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 2,
+    tenantId: 'tenant-A',
+  })
+
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'zzz-second')
+
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})

--- a/packages/backend/tests/unit/access/stock-tenant-access.unit.test.ts
+++ b/packages/backend/tests/unit/access/stock-tenant-access.unit.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import {
+  stockLocationTenantRead,
+  stockLevelTenantRead,
+} from '../../../src/access/is-admin-or-vendor-stock-tenant.ts'
+
+test('stockLocationTenantRead: unauthenticated', () => {
+  const r = stockLocationTenantRead({ req: {} } as never)
+  assert.equal(r, false)
+})
+
+test('stockLocationTenantRead: admin', () => {
+  const r = stockLocationTenantRead({ req: { user: { role: 'admin' } } } as never)
+  assert.equal(r, true)
+})
+
+test('stockLocationTenantRead: vendor with tenant object', () => {
+  const r = stockLocationTenantRead({
+    req: { user: { role: 'vendor', tenant: { id: 't-99' } } },
+  } as never)
+  assert.deepEqual(r, { tenant: { equals: 't-99' } })
+})
+
+test('stockLocationTenantRead: vendor with tenant string id', () => {
+  const r = stockLocationTenantRead({
+    req: { user: { role: 'vendor', tenant: 't-str' } },
+  } as never)
+  assert.deepEqual(r, { tenant: { equals: 't-str' } })
+})
+
+test('stockLocationTenantRead: vendor without tenant', () => {
+  const r = stockLocationTenantRead({ req: { user: { role: 'vendor' } } } as never)
+  assert.equal(r, false)
+})
+
+test('stockLocationTenantRead: customer', () => {
+  const r = stockLocationTenantRead({ req: { user: { role: 'customer' } } } as never)
+  assert.equal(r, false)
+})
+
+test('stockLevelTenantRead: vendor tenant filter uses nested location.tenant', () => {
+  const r = stockLevelTenantRead({
+    req: { user: { role: 'vendor', tenant: { id: 'v1' } } },
+  } as never)
+  assert.deepEqual(r, { 'location.tenant': { equals: 'v1' } })
+})
+
+test('stockLevelTenantRead: admin', () => {
+  assert.equal(stockLevelTenantRead({ req: { user: { role: 'admin' } } } as never), true)
+})
+
+test('stockLevelTenantRead: unauthenticated', () => {
+  assert.equal(stockLevelTenantRead({ req: {} } as never), false)
+})
+
+test('stockLevelTenantRead: vendor without tenant', () => {
+  assert.equal(stockLevelTenantRead({ req: { user: { role: 'vendor' } } } as never), false)
+})
+
+test('stockLevelTenantRead: vendor with tenant string id', () => {
+  const r = stockLevelTenantRead({
+    req: { user: { role: 'vendor', tenant: 't-str' } },
+  } as never)
+  assert.deepEqual(r, { 'location.tenant': { equals: 't-str' } })
+})

--- a/packages/backend/tests/unit/checkout/process-checkout.unit.test.ts
+++ b/packages/backend/tests/unit/checkout/process-checkout.unit.test.ts
@@ -6,11 +6,16 @@ import { processCheckout } from '../../../src/lib/process-checkout.ts'
 let envBackups: Record<string, string | undefined> = {}
 const envKeys = [
   'MULTIVENDOR_ENABLED',
+  'INVENTORY_ENABLED',
   'REQUIRE_VERIFIED_FOR_CHECKOUT',
   'DEFAULT_COMMISSION_RATE',
   'BS_TEST_ORDER_EMAIL_REJECT',
 ]
-beforeEach(() => { envBackups = {}; for (const k of envKeys) envBackups[k] = process.env[k] })
+beforeEach(() => {
+  envBackups = {}
+  for (const k of envKeys) envBackups[k] = process.env[k]
+  process.env.INVENTORY_ENABLED = 'false'
+})
 afterEach(() => { for (const k of envKeys) { if (envBackups[k] === undefined) delete process.env[k]; else process.env[k] = envBackups[k] } })
 
 function buildPayload(overrides: Record<string, Function> = {}) {
@@ -38,6 +43,9 @@ function buildPayload(overrides: Record<string, Function> = {}) {
       }
       if (args.collection === 'products') return defaultProduct
       if (args.collection === 'users') return { id: args.id, email: 'u@test.com', emailVerified: true }
+      if (args.collection === 'stock-levels') {
+        return { id: args.id, reservedQuantity: 0, quantity: 999 }
+      }
       return { id: args.id }
     },
     create: async (args: any) => {
@@ -436,7 +444,94 @@ test('should create sub-orders and platform line items when multivendor is enabl
   assert.equal(platformOnly.length, 1)
 })
 
+test('when multivendor and inventory enabled, should set stockLevel on vendor and platform line items', async () => {
+  process.env.MULTIVENDOR_ENABLED = 'true'
+  process.env.INVENTORY_ENABLED = 'true'
+  process.env.DEFAULT_COMMISSION_RATE = '10'
+
+  const payload = buildPayload({
+    findByID: async (args: any) => {
+      if (args.collection === 'stock-levels' && args.id === 'sl-v-t1') {
+        return { id: 'sl-v-t1', reservedQuantity: 0, quantity: 100 }
+      }
+      if (args.collection === 'stock-levels' && args.id === 'sl-plat') {
+        return { id: 'sl-plat', reservedQuantity: 0, quantity: 100 }
+      }
+      if (args.collection === 'carts') {
+        return {
+          id: 'cart-1',
+          guestId: 'guest-abc',
+          user: null,
+          items: [
+            { product: { id: 'p-v' }, quantity: 1, unitPrice: 10 },
+            { product: { id: 'p-plat' }, quantity: 1, unitPrice: 5 },
+          ],
+        }
+      }
+      if (args.collection === 'products') {
+        if (args.id === 'p-v') {
+          return { id: 'p-v', name: 'Vendor P', basePrice: 100, sku: 'V', tenant: { id: 't-1' } }
+        }
+        return { id: 'p-plat', name: 'Platform P', basePrice: 20, sku: 'P', tenant: null }
+      }
+      if (args.collection === 'stock-levels') return { id: args.id, reservedQuantity: 0, quantity: 999 }
+      return { id: args.id }
+    },
+    find: async (args: any) => {
+      if (args.collection === 'stock-levels') {
+        const pid = args.where?.product?.equals
+        if (pid === 'p-v') {
+          return {
+            docs: [
+              {
+                id: 'sl-v-t1',
+                product: 'p-v',
+                variant: null,
+                quantity: 100,
+                reservedQuantity: 0,
+                location: { tenant: { id: 't-1' } },
+              },
+            ],
+          }
+        }
+        if (pid === 'p-plat') {
+          return {
+            docs: [
+              {
+                id: 'sl-plat',
+                product: 'p-plat',
+                variant: null,
+                quantity: 100,
+                reservedQuantity: 0,
+                location: { tenant: null },
+              },
+            ],
+          }
+        }
+        return { docs: [] }
+      }
+      if (args.collection === 'vendor-settings') return { docs: [] }
+      if (args.collection === 'orders') return { docs: [] }
+      return { docs: [], totalDocs: 0 }
+    },
+  })
+
+  const result = await processCheckout(payload, { ...baseInput, guestEmail: 'mv-inv@test.com' }, undefined, guestReq())
+  assert.equal(result.error, undefined)
+
+  const itemCreates = payload._calls.create.filter((c: any) => c.collection === 'order-items')
+  assert.equal(itemCreates.length, 2)
+  const vendorLine = itemCreates.find((c: any) => c.data.product === 'p-v')
+  const platLine = itemCreates.find((c: any) => c.data.product === 'p-plat')
+  assert.equal(vendorLine?.data.stockLevel, 'sl-v-t1')
+  assert.equal(platLine?.data.stockLevel, 'sl-plat')
+
+  const stockUpdates = payload._calls.update.filter((c: any) => c.collection === 'stock-levels')
+  assert.equal(stockUpdates.length, 2)
+})
+
 test('should reserve stock when matching stock-level exists', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
   const payload = buildPayload({
     find: async (args: any) => {
       if (args.collection === 'stock-levels') {
@@ -445,13 +540,33 @@ test('should reserve stock when matching stock-level exists', async () => {
             {
               id: 'sl-1',
               product: 'prod-1',
+              variant: null,
+              quantity: 100,
               reservedQuantity: 1,
+              location: { tenant: null },
             },
           ],
         }
       }
       if (args.collection === 'orders') return { docs: [] }
       return { docs: [], totalDocs: 0 }
+    },
+    findByID: async (args: any) => {
+      if (args.collection === 'stock-levels' && args.id === 'sl-1') {
+        return { id: 'sl-1', reservedQuantity: 1, quantity: 100 }
+      }
+      if (args.collection === 'carts') {
+        return {
+          id: 'cart-1',
+          guestId: 'guest-abc',
+          user: null,
+          items: [{ product: { id: 'prod-1' }, quantity: 2, unitPrice: 50 }],
+        }
+      }
+      if (args.collection === 'products') return { id: 'prod-1', name: 'Test', basePrice: 50, tenant: null }
+      if (args.collection === 'users') return { id: args.id, email: 'u@test.com', emailVerified: true }
+      if (args.collection === 'stock-levels') return { id: args.id, reservedQuantity: 0, quantity: 999 }
+      return { id: args.id }
     },
   })
   await processCheckout(payload, { ...baseInput, guestEmail: 'stock@test.com' }, undefined, guestReq())
@@ -740,8 +855,30 @@ test('should use pending in status history when created order has no status fiel
 })
 
 test('should reserve stock matching product and variant on stock level', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
   const payload = buildPayload({
+    find: async (args: any) => {
+      if (args.collection === 'stock-levels') {
+        return {
+          docs: [
+            {
+              id: 'sl-v',
+              product: 'prod-1',
+              variant: 'var-1',
+              quantity: 50,
+              reservedQuantity: 1,
+              location: { tenant: null },
+            },
+          ],
+        }
+      }
+      if (args.collection === 'orders') return { docs: [] }
+      return { docs: [], totalDocs: 0 }
+    },
     findByID: async (args: any) => {
+      if (args.collection === 'stock-levels' && args.id === 'sl-v') {
+        return { id: 'sl-v', reservedQuantity: 1, quantity: 50 }
+      }
       if (args.collection === 'carts') {
         return {
           id: 'cart-1',
@@ -761,23 +898,8 @@ test('should reserve stock matching product and variant on stock level', async (
       if (args.collection === 'product-variants') {
         return { id: 'var-1', price: 10, sku: 'V1' }
       }
+      if (args.collection === 'stock-levels') return { id: args.id, reservedQuantity: 0, quantity: 999 }
       return { id: args.id }
-    },
-    find: async (args: any) => {
-      if (args.collection === 'stock-levels') {
-        return {
-          docs: [
-            {
-              id: 'sl-v',
-              product: 'prod-1',
-              variant: 'var-1',
-              reservedQuantity: 1,
-            },
-          ],
-        }
-      }
-      if (args.collection === 'orders') return { docs: [] }
-      return { docs: [], totalDocs: 0 }
     },
   })
   await processCheckout(payload, { ...baseInput, guestEmail: 'sv@t.com' }, undefined, guestReq())
@@ -1084,6 +1206,7 @@ test('should increment coupon uses when totalUses is undefined on stored coupon'
 })
 
 test('should reserve stock when stock level uses object ids', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
   const payload = buildPayload({
     find: async (args: any) => {
       if (args.collection === 'stock-levels') {
@@ -1093,7 +1216,9 @@ test('should reserve stock when stock level uses object ids', async () => {
               id: 'sl-obj',
               product: { id: 'prod-1' },
               variant: { id: 'var-1' },
+              quantity: 50,
               reservedQuantity: 0,
+              location: { tenant: null },
             },
           ],
         }
@@ -1102,6 +1227,9 @@ test('should reserve stock when stock level uses object ids', async () => {
       return { docs: [], totalDocs: 0 }
     },
     findByID: async (args: any) => {
+      if (args.collection === 'stock-levels' && args.id === 'sl-obj') {
+        return { id: 'sl-obj', reservedQuantity: 0, quantity: 50 }
+      }
       if (args.collection === 'carts') {
         return {
           id: 'cart-1',
@@ -1119,6 +1247,7 @@ test('should reserve stock when stock level uses object ids', async () => {
       }
       if (args.collection === 'products') return { id: 'prod-1', name: 'P', basePrice: 10, tenant: null }
       if (args.collection === 'product-variants') return { id: 'var-1', price: 10, sku: 'V1' }
+      if (args.collection === 'stock-levels') return { id: args.id, reservedQuantity: 0, quantity: 999 }
       return { id: args.id }
     },
   })
@@ -1128,7 +1257,8 @@ test('should reserve stock when stock level uses object ids', async () => {
   assert.equal(stockUpdates[0].data.reservedQuantity, 2)
 })
 
-test('should skip stock update when no stock level row matches', async () => {
+test('should return error when no stock level row matches product variant', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
   const payload = buildPayload({
     find: async (args: any) => {
       if (args.collection === 'stock-levels') {
@@ -1138,7 +1268,9 @@ test('should skip stock update when no stock level row matches', async () => {
               id: 'sl-x',
               product: 'prod-1',
               variant: 'other-variant',
+              quantity: 10,
               reservedQuantity: 0,
+              location: { tenant: null },
             },
           ],
         }
@@ -1147,7 +1279,48 @@ test('should skip stock update when no stock level row matches', async () => {
       return { docs: [], totalDocs: 0 }
     },
   })
-  await processCheckout(payload, { ...baseInput, guestEmail: 'slmiss@test.com' }, undefined, guestReq())
+  const result = await processCheckout(payload, { ...baseInput, guestEmail: 'slmiss@test.com' }, undefined, guestReq())
+  assert.equal(result.statusCode, 400)
+  assert.ok(result.error?.includes('stock') || result.error?.includes('warehouse'))
+})
+
+test('should skip stock reserve update when stock-level doc missing at reserve time', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
+  const payload = buildPayload({
+    find: async (args: any) => {
+      if (args.collection === 'stock-levels') {
+        return {
+          docs: [
+            {
+              id: 'sl-m',
+              product: 'prod-1',
+              variant: null,
+              quantity: 100,
+              reservedQuantity: 0,
+              location: { tenant: null },
+            },
+          ],
+        }
+      }
+      if (args.collection === 'orders') return { docs: [] }
+      return { docs: [], totalDocs: 0 }
+    },
+    findByID: async (args: any) => {
+      if (args.collection === 'carts') {
+        return {
+          id: 'cart-1',
+          guestId: 'guest-abc',
+          user: null,
+          items: [{ product: { id: 'prod-1' }, quantity: 2, unitPrice: 50 }],
+        }
+      }
+      if (args.collection === 'products') return { id: 'prod-1', name: 'P', basePrice: 50, tenant: null }
+      if (args.collection === 'stock-levels' && args.id === 'sl-m') return null
+      if (args.collection === 'stock-levels') return { id: args.id, reservedQuantity: 0, quantity: 999 }
+      return { id: args.id }
+    },
+  })
+  await processCheckout(payload, { ...baseInput, guestEmail: 'resgap@test.com' }, undefined, guestReq())
   const stockUpdates = payload._calls.update.filter((c: any) => c.collection === 'stock-levels')
   assert.equal(stockUpdates.length, 0)
 })

--- a/packages/backend/tests/unit/collections/config-access-wiring.unit.test.ts
+++ b/packages/backend/tests/unit/collections/config-access-wiring.unit.test.ts
@@ -14,6 +14,8 @@ import { VendorApplications } from '../../../src/plugins/multivendor/collections
 import { ShippingMethods } from '../../../src/plugins/shipping/collections/shipping-methods.ts'
 // @ts-ignore
 import { ShippingZones } from '../../../src/plugins/shipping/collections/shipping-zones.ts'
+// @ts-ignore
+import { createStockLocationsConfig } from '../../../src/plugins/inventory/collections/stock-locations.ts'
 
 test('Users access.create allows registration', () => {
   const create = Users.access?.create as (args: { req?: unknown }) => boolean
@@ -74,4 +76,17 @@ test('ShippingZones access.read is public', () => {
   const read = ShippingZones.access?.read as (args: { req?: unknown }) => boolean
   assert.ok(typeof read === 'function')
   assert.equal(read({ req: {} } as never), true)
+})
+
+test('createStockLocationsConfig(true) adds tenant field and column (multivendor inventory)', () => {
+  const cfg = createStockLocationsConfig(true)
+  const names = (cfg.fields ?? []).map((f) => (f as { name?: string }).name)
+  assert.ok(names.includes('tenant'))
+  assert.ok(cfg.admin?.defaultColumns?.includes('tenant'))
+})
+
+test('createStockLocationsConfig(false) has no tenant field', () => {
+  const cfg = createStockLocationsConfig(false)
+  const names = (cfg.fields ?? []).map((f) => (f as { name?: string }).name)
+  assert.ok(!names.includes('tenant'))
 })

--- a/packages/backend/tests/unit/collections/order-items-hooks.unit.test.ts
+++ b/packages/backend/tests/unit/collections/order-items-hooks.unit.test.ts
@@ -5,7 +5,7 @@ import { createOrderItemsConfig } from '../../../src/plugins/orders/collections/
 
 test('beforeChange uses NaN quantity when quantity is undefined but productName set', () => {
   const cfg = createOrderItemsConfig(false)
-  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const hook = cfg.hooks?.beforeChange?.[2] as any
   const data = { productName: 'Widget', quantity: undefined } as any
   const out = hook({ data })
   assert.ok(String(out.itemLabel).includes('NaN'))
@@ -13,7 +13,7 @@ test('beforeChange uses NaN quantity when quantity is undefined but productName 
 
 test('beforeChange should set itemLabel from productName and quantity', () => {
   const cfg = createOrderItemsConfig(false)
-  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const hook = cfg.hooks?.beforeChange?.[2] as any
   assert.ok(hook)
   const data = { productName: 'Widget', quantity: 3 } as any
   const out = hook({ data })
@@ -22,7 +22,7 @@ test('beforeChange should set itemLabel from productName and quantity', () => {
 
 test('beforeChange should not set itemLabel when productName is absent', () => {
   const cfg = createOrderItemsConfig(false)
-  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const hook = cfg.hooks?.beforeChange?.[2] as any
   const data = { quantity: 2 } as any
   const out = hook({ data })
   assert.equal(out.itemLabel, undefined)
@@ -57,4 +57,333 @@ test('access read allows vendor owner filter when multivendor', () => {
   const read = cfg.access?.read as any
   const r = read({ req: { user: { role: 'vendor', tenant: { id: 't-1' } } } })
   assert.ok(typeof r === 'object' && r.tenant?.equals === 't-1')
+})
+
+test('beforeChange[0]: vendor cannot change fields other than stockLevel', () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  assert.throws(
+    () =>
+      hook({
+        operation: 'update',
+        data: { productName: 'Hacked' },
+        originalDoc: { id: 'oi-1' },
+        req: { user: { role: 'vendor' } },
+      }),
+    /Vendors may only update fulfillment warehouse/,
+  )
+})
+
+test('beforeChange[0]: vendor may send stockLevel with updatedAt', () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const data = { stockLevel: 'sl-new', updatedAt: '2020-01-01T00:00:00.000Z' }
+  const out = hook({
+    operation: 'update',
+    data,
+    originalDoc: { id: 'oi-1' },
+    req: { user: { role: 'vendor' } },
+  })
+  assert.equal(out, data)
+})
+
+test('beforeChange[0]: vendor may send only stockLevel', () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const data = { stockLevel: 'sl-new' }
+  const out = hook({
+    operation: 'update',
+    data,
+    originalDoc: { id: 'oi-1' },
+    req: { user: { role: 'vendor' } },
+  })
+  assert.equal(out, data)
+})
+
+test('beforeChange[0]: vendor may send Payload-merged body (unchanged fields + stockLevel)', () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const data = {
+    order: 'ord-1',
+    product: 'prod-1',
+    quantity: 2,
+    unitPrice: 10,
+    totalPrice: 20,
+    productName: 'Widget',
+    stockLevel: 'sl-new',
+  }
+  const originalDoc = {
+    id: 'oi-1',
+    order: 'ord-1',
+    product: 'prod-1',
+    quantity: 2,
+    unitPrice: 10,
+    totalPrice: 20,
+    productName: 'Widget',
+    stockLevel: 'sl-old',
+  }
+  const out = hook({
+    operation: 'update',
+    data,
+    originalDoc,
+    req: { user: { role: 'vendor' } },
+  })
+  assert.equal(out, data)
+})
+
+test('beforeChange[0]: vendor merged body treats relationship object id same as string id', () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const data = {
+    order: { id: 'ord-1' },
+    product: 'prod-1',
+    quantity: 1,
+    unitPrice: 10,
+    totalPrice: 10,
+    productName: 'Widget',
+    stockLevel: 'sl-new',
+  }
+  const originalDoc = {
+    id: 'oi-1',
+    order: 'ord-1',
+    product: 'prod-1',
+    quantity: 1,
+    unitPrice: 10,
+    totalPrice: 10,
+    productName: 'Widget',
+    stockLevel: 'sl-old',
+  }
+  const out = hook({
+    operation: 'update',
+    data,
+    originalDoc,
+    req: { user: { role: 'vendor' } },
+  })
+  assert.equal(out, data)
+})
+
+test('beforeChange[0]: vendor merged body rejects different relationship id (non-null vs non-null)', () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  assert.throws(
+    () =>
+      hook({
+        operation: 'update',
+        data: {
+          order: 'ord-2',
+          product: 'prod-1',
+          quantity: 1,
+          unitPrice: 10,
+          totalPrice: 10,
+          productName: 'Widget',
+          stockLevel: 'sl-new',
+        },
+        originalDoc: {
+          id: 'oi-1',
+          order: 'ord-1',
+          product: 'prod-1',
+          quantity: 1,
+          unitPrice: 10,
+          totalPrice: 10,
+          productName: 'Widget',
+          stockLevel: 'sl-old',
+        },
+        req: { user: { role: 'vendor' } },
+      }),
+    /Vendors may only update fulfillment warehouse/,
+  )
+})
+
+test('beforeChange[0]: vendor merged body allows null vs absent optional field', () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  const data = {
+    order: 'ord-1',
+    product: 'prod-1',
+    quantity: 1,
+    unitPrice: 10,
+    totalPrice: 10,
+    productName: 'Widget',
+    variant: null,
+    stockLevel: 'sl-new',
+  }
+  const originalDoc = {
+    id: 'oi-1',
+    order: 'ord-1',
+    product: 'prod-1',
+    quantity: 1,
+    unitPrice: 10,
+    totalPrice: 10,
+    productName: 'Widget',
+    stockLevel: 'sl-old',
+  }
+  const out = hook({
+    operation: 'update',
+    data,
+    originalDoc,
+    req: { user: { role: 'vendor' } },
+  })
+  assert.equal(out, data)
+})
+
+test('beforeChange[1]: transfers reservation when stockLevel id changes', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  const updates: Array<{ id: string; data: { reservedQuantity: number } }> = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'sl-old'
+        ? { id: 'sl-old', reservedQuantity: 4, quantity: 20 }
+        : { id: 'sl-new', reservedQuantity: 0, quantity: 30 },
+    update: async (args: { id: string; data: { reservedQuantity: number } }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  const data = { stockLevel: 'sl-new' }
+  const out = await hook({
+    operation: 'update',
+    data,
+    originalDoc: { stockLevel: 'sl-old', quantity: 2 },
+    req: { payload, user: { role: 'admin' } },
+  })
+  assert.equal(out, data)
+  assert.equal(updates.length, 2)
+})
+
+test('beforeChange[1]: returns early when not update operation', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  const out = await hook({
+    operation: 'create',
+    data: { stockLevel: 'x' },
+    originalDoc: { stockLevel: 'y', quantity: 1 },
+    req: { payload: {} },
+  })
+  assert.equal(out?.stockLevel, 'x')
+})
+
+test('beforeChange[1]: returns when stockLevel omitted', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  const data = { productName: 'x' }
+  const out = await hook({
+    operation: 'update',
+    data,
+    originalDoc: { stockLevel: 'a', quantity: 1 },
+    req: { payload: {} },
+  })
+  assert.equal(out, data)
+})
+
+test('beforeChange[1]: transfer uses quantity 1 when original quantity is zero', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  const updates: Array<{ quantity?: number }> = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'old-sl'
+        ? { id: 'old-sl', reservedQuantity: 2, quantity: 10 }
+        : { id: 'new-sl', reservedQuantity: 0, quantity: 10 },
+    update: async (args: unknown) => {
+      updates.push(args as { quantity?: number })
+      return {}
+    },
+  }
+  await hook({
+    operation: 'update',
+    data: { stockLevel: 'new-sl' },
+    originalDoc: { stockLevel: 'old-sl', quantity: 0 },
+    req: { payload },
+  })
+  assert.equal(updates.length, 2)
+})
+
+test('beforeChange[1]: relationId stringifies object stockLevel without id field', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  const updates: unknown[] = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === '[object Object]'
+        ? { id: '[object Object]', reservedQuantity: 1, quantity: 10 }
+        : { id: 'new-sl', reservedQuantity: 0, quantity: 10 },
+    update: async (args: unknown) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await hook({
+    operation: 'update',
+    data: { stockLevel: 'new-sl' },
+    originalDoc: { stockLevel: {}, quantity: 1 },
+    req: { payload },
+  })
+  assert.equal(updates.length, 2)
+})
+
+test('beforeChange[1]: relationId accepts numeric stockLevel refs', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  const updates: unknown[] = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === '5'
+        ? { id: '5', reservedQuantity: 2, quantity: 10 }
+        : { id: '9', reservedQuantity: 0, quantity: 10 },
+    update: async (args: unknown) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await hook({
+    operation: 'update',
+    data: { stockLevel: '9' },
+    originalDoc: { stockLevel: 5, quantity: 1 },
+    req: { payload },
+  })
+  assert.equal(updates.length, 2)
+})
+
+test('beforeChange[1]: uses relationId for object stockLevel refs', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  const updates: unknown[] = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'old-sl'
+        ? { id: 'old-sl', reservedQuantity: 3, quantity: 20 }
+        : { id: 'new-sl', reservedQuantity: 0, quantity: 20 },
+    update: async (args: unknown) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await hook({
+    operation: 'update',
+    data: { stockLevel: { id: 'new-sl' } },
+    originalDoc: { stockLevel: { id: 'old-sl' }, quantity: 1 },
+    req: { payload },
+  })
+  assert.equal(updates.length, 2)
+})
+
+test('beforeChange[1]: no transfer when stockLevel unchanged', async () => {
+  const cfg = createOrderItemsConfig(true)
+  const hook = cfg.hooks?.beforeChange?.[1] as any
+  let updateCalls = 0
+  const payload = {
+    findByID: async () => ({ id: 'sl-1', reservedQuantity: 1, quantity: 10 }),
+    update: async () => {
+      updateCalls++
+      return {}
+    },
+  }
+  await hook({
+    operation: 'update',
+    data: { stockLevel: 'sl-1' },
+    originalDoc: { stockLevel: 'sl-1', quantity: 1 },
+    req: { payload },
+  })
+  assert.equal(updateCalls, 0)
 })

--- a/packages/backend/tests/unit/lib/allocate-stock-level.unit.test.ts
+++ b/packages/backend/tests/unit/lib/allocate-stock-level.unit.test.ts
@@ -1,0 +1,551 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { allocateStockLevelForLine } from '../../../src/lib/allocate-stock-level.ts'
+
+test('should pick first stock-level by id when sufficient available (MV off)', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-b',
+          product: 'p1',
+          variant: null,
+          quantity: 10,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'sl-a',
+          product: 'p1',
+          variant: null,
+          quantity: 5,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 3,
+    tenantId: null,
+  })
+
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-a')
+
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('should return error when no row has enough in one warehouse', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-1',
+          product: 'p1',
+          variant: null,
+          quantity: 2,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'sl-2',
+          product: 'p1',
+          variant: null,
+          quantity: 2,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 3,
+    tenantId: null,
+  })
+
+  assert.ok('error' in r)
+
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('when MULTIVENDOR_ENABLED=true, tenant product uses only warehouses for that tenant', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'true'
+
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-other',
+          product: 'p1',
+          variant: null,
+          quantity: 999,
+          reservedQuantity: 0,
+          location: { tenant: { id: 'tenant-B' } },
+        },
+        {
+          id: 'sl-own',
+          product: 'p1',
+          variant: null,
+          quantity: 50,
+          reservedQuantity: 0,
+          location: { tenant: { id: 'tenant-A' } },
+        },
+      ],
+    }),
+  }
+
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 2,
+    tenantId: 'tenant-A',
+  })
+
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-own')
+
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('when MULTIVENDOR_ENABLED=true, platform product uses only platform warehouses', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'true'
+
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-vendor-wh',
+          product: 'p1',
+          variant: null,
+          quantity: 999,
+          reservedQuantity: 0,
+          location: { tenant: { id: 'tenant-X' } },
+        },
+        {
+          id: 'sl-platform',
+          product: 'p1',
+          variant: null,
+          quantity: 20,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 1,
+    tenantId: null,
+  })
+
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-platform')
+
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('when MULTIVENDOR_ENABLED=true, should error when only other-tenant warehouses have stock', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'true'
+
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-b',
+          product: 'p1',
+          variant: null,
+          quantity: 100,
+          reservedQuantity: 0,
+          location: { tenant: { id: 'tenant-other' } },
+        },
+      ],
+    }),
+  }
+
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 1,
+    tenantId: 'tenant-A',
+  })
+
+  assert.ok('error' in r)
+  assert.ok((r as { error: string }).error.includes('No stock configured') || (r as { error: string }).error.includes('warehouse'))
+
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('should return error when quantity < 1', async () => {
+  const payload = { find: async () => ({ docs: [] }) }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 0,
+    tenantId: null,
+  })
+  assert.ok('error' in r)
+  assert.ok((r as { error: string }).error.includes('Invalid quantity'))
+})
+
+test('should error when no stock rows match product (empty candidates)', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({ docs: [] }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 1,
+    tenantId: null,
+  })
+  assert.ok('error' in r)
+  assert.ok((r as { error: string }).error.includes('No stock configured'))
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('should error when total available across rows is less than quantity', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-1',
+          product: 'p1',
+          variant: null,
+          quantity: 2,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'sl-2',
+          product: 'p1',
+          variant: null,
+          quantity: 2,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 10,
+    tenantId: null,
+  })
+  assert.ok('error' in r)
+  assert.ok((r as { error: string }).error.includes('Insufficient stock across warehouses'))
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('should error when sum of warehouses is enough but no single row can fulfill (split line)', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'a',
+          product: 'p1',
+          variant: null,
+          quantity: 3,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'b',
+          product: 'p1',
+          variant: null,
+          quantity: 3,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 4,
+    tenantId: null,
+  })
+  assert.ok('error' in r)
+  assert.ok((r as { error: string }).error.includes('single warehouse'))
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('matches variant when stock row stores variant as populated object', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-vobj',
+          product: 'p1',
+          variant: { id: 'var-obj' },
+          quantity: 10,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: 'var-obj',
+    quantity: 1,
+    tenantId: null,
+  })
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-vobj')
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('should pick stock row matching explicit variantId', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-var',
+          product: 'p1',
+          variant: 'var-99',
+          quantity: 10,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'sl-base',
+          product: 'p1',
+          variant: null,
+          quantity: 50,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: 'var-99',
+    quantity: 2,
+    tenantId: null,
+  })
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-var')
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('treats non-object location as no tenant (still matches platform warehouse)', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-prim',
+          product: 'p1',
+          variant: null,
+          quantity: 10,
+          reservedQuantity: 0,
+          location: 42,
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 1,
+    tenantId: null,
+  })
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-prim')
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('reduce branch uses Number coalescing for totalAvailable', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'a',
+          product: 'p1',
+          variant: null,
+          quantity: Number.NaN,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'b',
+          product: 'p1',
+          variant: null,
+          quantity: 2,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 10,
+    tenantId: null,
+  })
+  assert.ok('error' in r)
+  assert.ok((r as { error: string }).error.includes('Insufficient stock across warehouses'))
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('skips candidate with NaN quantity then picks next row', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-bad',
+          product: 'p1',
+          variant: null,
+          quantity: Number.NaN,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'sl-ok',
+          product: 'p1',
+          variant: null,
+          quantity: 10,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 1,
+    tenantId: null,
+  })
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-ok')
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('matchesProductVariant handles product field null on stock row', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-null-prod',
+          product: null,
+          variant: null,
+          quantity: 50,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+        {
+          id: 'sl-ok',
+          product: 'p1',
+          variant: null,
+          quantity: 5,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 1,
+    tenantId: null,
+  })
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-ok')
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('matches product when stock row has product as populated object', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'false'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-obj',
+          product: { id: 'p1' },
+          variant: null,
+          quantity: 5,
+          reservedQuantity: 0,
+          location: { tenant: null },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 2,
+    tenantId: null,
+  })
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-obj')
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
+test('location tenant as string id still matches vendor filter', async () => {
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.MULTIVENDOR_ENABLED = 'true'
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-1',
+          product: 'p1',
+          variant: null,
+          quantity: 10,
+          reservedQuantity: 0,
+          location: { tenant: 'tenant-A' },
+        },
+      ],
+    }),
+  }
+  const r = await allocateStockLevelForLine(payload as never, {
+    productId: 'p1',
+    variantId: null,
+    quantity: 1,
+    tenantId: 'tenant-A',
+  })
+  assert.ok('stockLevelId' in r)
+  assert.equal((r as { stockLevelId: string }).stockLevelId, 'sl-1')
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})

--- a/packages/backend/tests/unit/lib/build-reserve-quantities-by-stock-level.unit.test.ts
+++ b/packages/backend/tests/unit/lib/build-reserve-quantities-by-stock-level.unit.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import { buildReserveQuantitiesByStockLevel } from '../../../src/lib/build-reserve-quantities-by-stock-level.ts'
+
+const base = {
+  productId: 'p',
+  variantId: null as string | null,
+  productName: 'P',
+  variantName: '',
+  sku: '',
+  quantity: 1,
+  unitPrice: 1,
+  totalPrice: 1,
+  productImage: '',
+  tenantId: null as string | null,
+}
+
+test('empty input yields empty map', () => {
+  const m = buildReserveQuantitiesByStockLevel([])
+  assert.equal(m.size, 0)
+})
+
+test('skips lines without stockLevelId', () => {
+  const m = buildReserveQuantitiesByStockLevel([
+    { ...base, quantity: 2 },
+    { ...base, stockLevelId: 'sl-1', quantity: 3 },
+  ] as never[])
+  assert.equal(m.size, 1)
+  assert.equal(m.get('sl-1'), 3)
+})
+
+test('sums quantities for the same stockLevelId', () => {
+  const m = buildReserveQuantitiesByStockLevel([
+    { ...base, stockLevelId: 'a', quantity: 2 },
+    { ...base, stockLevelId: 'a', quantity: 4 },
+    { ...base, stockLevelId: 'b', quantity: 1 },
+  ] as never[])
+  assert.equal(m.get('a'), 6)
+  assert.equal(m.get('b'), 1)
+})

--- a/packages/backend/tests/unit/lib/consume-order-inventory.unit.test.ts
+++ b/packages/backend/tests/unit/lib/consume-order-inventory.unit.test.ts
@@ -3,236 +3,367 @@ import assert from 'node:assert/strict'
 // @ts-ignore
 import { consumeOrderInventory } from '../../../src/lib/consume-order-inventory.ts'
 
-test('should no-op when items array is empty', async () => {
-  let findCalls = 0
-  const payload = {
-    find: async () => {
-      findCalls++
-      return { docs: [] }
-    },
-    update: async () => ({}),
-  }
-  await consumeOrderInventory(payload as any, [])
-  assert.equal(findCalls, 0)
+test('consumeOrderInventory: no-op for empty items', async () => {
+  await consumeOrderInventory({} as never, [])
 })
 
-test('should default quantity to 1 when line quantity is zero or missing', async () => {
-  const updates: any[] = []
+test('consumeOrderInventory: direct path uses quantity 1 when item quantity is zero', async () => {
+  const updates: Array<{ data: Record<string, number> }> = []
   const payload = {
-    find: async () => ({
-      docs: [
-        {
-          id: 'sl-q',
-          product: 'p-1',
-          variant: null,
-          quantity: 5,
-          reservedQuantity: 1,
-        },
-      ],
+    find: async () => ({ docs: [] }),
+    findByID: async () => ({
+      id: 'sl-1',
+      quantity: 5,
+      reservedQuantity: 2,
     }),
-    update: async (args: any) => {
+    update: async (args: { data: Record<string, number> }) => {
       updates.push(args)
       return {}
     },
   }
-  await consumeOrderInventory(payload as any, [
-    { product: 'p-1', quantity: 0 },
-    { product: 'p-1', quantity: undefined as any },
-  ])
-  assert.equal(updates.length, 2)
+  await consumeOrderInventory(
+    payload as never,
+    [{ stockLevel: 'sl-1', quantity: 0, product: 'p1' } as never],
+  )
+  assert.equal(updates[0]?.data.quantity, 4)
+  assert.equal(updates[0]?.data.reservedQuantity, 1)
 })
 
-test('should decrement quantity and reserved when stock level matches', async () => {
-  const updates: any[] = []
+test('consumeOrderInventory: direct path coerces missing level quantities with Number', async () => {
+  const updates: Array<{ data: Record<string, number> }> = []
+  const payload = {
+    find: async () => ({ docs: [] }),
+    findByID: async () => ({
+      id: 'sl-1',
+      quantity: undefined,
+      reservedQuantity: undefined,
+    }),
+    update: async (args: { data: Record<string, number> }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ stockLevel: 'sl-1', quantity: 2, product: 'p1' } as never])
+  assert.equal(updates[0]?.data.quantity, 0)
+  assert.equal(updates[0]?.data.reservedQuantity, 0)
+})
+
+test('consumeOrderInventory: direct stockLevel path updates quantity and reserved', async () => {
+  const updates: Array<{ id: string; data: Record<string, number> }> = []
+  const payload = {
+    find: async () => ({ docs: [] }),
+    findByID: async ({ id }: { id: string }) => ({
+      id,
+      quantity: 20,
+      reservedQuantity: 8,
+    }),
+    update: async (args: { id: string; data: Record<string, number> }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await consumeOrderInventory(
+    payload as never,
+    [{ stockLevel: 'sl-1', quantity: 3, product: 'p1' } as never],
+    { req: true } as never,
+  )
+  assert.equal(updates.length, 1)
+  assert.equal(updates[0].id, 'sl-1')
+  assert.equal(updates[0].data.quantity, 17)
+  assert.equal(updates[0].data.reservedQuantity, 5)
+})
+
+test('consumeOrderInventory: skips when findByID returns null for direct stockLevel', async () => {
+  let updates = 0
+  const payload = {
+    find: async () => ({ docs: [] }),
+    findByID: async () => null,
+    update: async () => {
+      updates++
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ stockLevel: 'missing', quantity: 1, product: 'p1' } as never])
+  assert.equal(updates, 0)
+})
+
+test('consumeOrderInventory: legacy match by product + variant', async () => {
+  const updates: Array<{ id: string }> = []
   const payload = {
     find: async () => ({
       docs: [
         {
-          id: 'sl-1',
-          product: 'p-1',
-          variant: null,
+          id: 'sl-leg',
+          product: 'p1',
+          variant: 'v1',
           quantity: 10,
           reservedQuantity: 4,
         },
       ],
     }),
-    update: async (args: any) => {
+    findByID: async () => null,
+    update: async (args: { id: string }) => {
       updates.push(args)
       return {}
     },
   }
-  await consumeOrderInventory(
-    payload as any,
-    [{ product: 'p-1', quantity: 3 }],
-    {} as any,
-  )
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].data.quantity, 7)
-  assert.equal(updates[0].data.reservedQuantity, 1)
+  await consumeOrderInventory(payload as never, [
+    { product: 'p1', variant: 'v1', quantity: 2 } as never,
+  ])
+  assert.equal(updates[0]?.id, 'sl-leg')
 })
 
-test('should skip items without product but still process others', async () => {
-  const updates: any[] = []
+test('consumeOrderInventory: legacy product object id', async () => {
+  const updates: Array<{ id: string }> = []
   const payload = {
     find: async () => ({
       docs: [
         {
-          id: 'sl-1',
-          product: 'p-1',
+          id: 'sl-o',
+          product: { id: 'p-obj' },
           variant: null,
           quantity: 5,
           reservedQuantity: 1,
         },
       ],
     }),
-    update: async (args: any) => {
+    update: async (args: { id: string }) => {
       updates.push(args)
       return {}
     },
   }
-  await consumeOrderInventory(payload as any, [
-    { product: undefined, quantity: 9 } as any,
-    { product: 'p-1', quantity: 2 },
-  ])
-  assert.equal(updates.length, 1)
+  await consumeOrderInventory(payload as never, [{ product: { id: 'p-obj' }, quantity: 1 } as never])
+  assert.equal(updates[0]?.id, 'sl-o')
 })
 
-test('should treat variant object without id as no variant when matching', async () => {
-  const updates: any[] = []
+test('consumeOrderInventory: all direct stockLevel skips legacy stock-level find', async () => {
+  let findCalls = 0
+  const payload = {
+    find: async (args: { collection: string }) => {
+      if (args.collection === 'stock-levels') findCalls++
+      return { docs: [] }
+    },
+    findByID: async ({ id }: { id: string }) => ({
+      id,
+      quantity: 5,
+      reservedQuantity: 2,
+    }),
+    update: async () => ({}),
+  }
+  await consumeOrderInventory(payload as never, [
+    { stockLevel: 'sl-a', quantity: 1, product: 'p1' } as never,
+    { stockLevel: 'sl-b', quantity: 1, product: 'p1' } as never,
+  ])
+  assert.equal(findCalls, 0)
+})
+
+test('consumeOrderInventory: legacy skips line without product', async () => {
+  let updates = 0
+  const payload = {
+    find: async () => ({ docs: [] }),
+    update: async () => {
+      updates++
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ quantity: 1 } as never])
+  assert.equal(updates, 0)
+})
+
+test('consumeOrderInventory: legacy variant as object id', async () => {
+  const updates: Array<{ id: string }> = []
   const payload = {
     find: async () => ({
       docs: [
         {
-          id: 'sl-nov',
-          product: 'p-1',
-          variant: null,
-          quantity: 3,
+          id: 'sl-vobj',
+          product: 'p1',
+          variant: 'v-1',
+          quantity: 4,
           reservedQuantity: 1,
         },
       ],
     }),
-    update: async (args: any) => {
+    update: async (args: { id: string }) => {
       updates.push(args)
       return {}
     },
   }
-  await consumeOrderInventory(payload as any, [
-    { product: 'p-1', variant: {} as any, quantity: 1 },
+  await consumeOrderInventory(payload as never, [
+    { product: 'p1', variant: { id: 'v-1' }, quantity: 1 } as never,
   ])
-  assert.equal(updates.length, 1)
+  assert.equal(updates[0]?.id, 'sl-vobj')
 })
 
-test('should use zero when stock level quantity is missing', async () => {
-  const updates: any[] = []
+test('consumeOrderInventory: legacy no matching stock row', async () => {
+  let updates = 0
   const payload = {
     find: async () => ({
       docs: [
         {
-          id: 'sl-nq',
-          product: 'p-nq',
-          variant: null,
+          id: 'sl-other',
+          product: 'p1',
+          variant: 'v-x',
+          quantity: 4,
+          reservedQuantity: 1,
+        },
+      ],
+    }),
+    update: async () => {
+      updates++
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ product: 'p1', variant: 'v-y', quantity: 1 } as never])
+  assert.equal(updates, 0)
+})
+
+test('consumeOrderInventory: legacy matches stock row with variant as object id', async () => {
+  const updates: Array<{ id: string }> = []
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-var-obj',
+          product: 'p1',
+          variant: { id: 'vx' },
+          quantity: 6,
           reservedQuantity: 2,
         },
       ],
     }),
-    update: async (args: any) => {
+    update: async (args: { id: string }) => {
       updates.push(args)
       return {}
     },
   }
-  await consumeOrderInventory(payload as any, [{ product: 'p-nq', quantity: 1 }])
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].data.quantity, 0)
+  await consumeOrderInventory(payload as never, [{ product: 'p1', variant: 'vx', quantity: 1 } as never])
+  assert.equal(updates[0]?.id, 'sl-var-obj')
 })
 
-test('should match when variant is a numeric id', async () => {
-  const updates: any[] = []
+test('consumeOrderInventory: legacy update without req', async () => {
+  const seenReq: unknown[] = []
+  const payload = {
+    find: async () => ({
+      docs: [{ id: 'sl-1', product: 'p1', variant: null, quantity: 3, reservedQuantity: 1 }],
+    }),
+    update: async (args: { req?: unknown }) => {
+      seenReq.push(args.req)
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ product: 'p1', quantity: 1 } as never])
+  assert.equal(seenReq[0], undefined)
+})
+
+test('consumeOrderInventory: legacy uses explicit quantity when set', async () => {
+  const updates: Array<{ data: Record<string, number> }> = []
   const payload = {
     find: async () => ({
       docs: [
         {
-          id: 'sl-num',
-          product: 'p-1',
-          variant: 9,
-          quantity: 2,
+          id: 'sl-q',
+          product: 'p1',
+          variant: null,
+          quantity: 20,
+          reservedQuantity: 10,
+        },
+      ],
+    }),
+    update: async (args: { data: Record<string, number> }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ product: 'p1', quantity: 4 } as never])
+  assert.equal(updates[0]?.data.quantity, 16)
+  assert.equal(updates[0]?.data.reservedQuantity, 6)
+})
+
+test('consumeOrderInventory: legacy coerces NaN item quantity to 1', async () => {
+  const updates: Array<{ data: Record<string, number> }> = []
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-n',
+          product: 'p1',
+          variant: null,
+          quantity: 5,
+          reservedQuantity: 2,
+        },
+      ],
+    }),
+    update: async (args: { data: Record<string, number> }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ product: 'p1', quantity: Number.NaN } as never])
+  assert.equal(updates[0]?.data.quantity, 4)
+  assert.equal(updates[0]?.data.reservedQuantity, 1)
+})
+
+test('consumeOrderInventory: legacy treats zero quantity on level row with Number || 0', async () => {
+  const updates: Array<{ data: Record<string, number> }> = []
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-z',
+          product: 'p1',
+          variant: null,
+          quantity: 0,
           reservedQuantity: 0,
         },
       ],
     }),
-    update: async (args: any) => {
+    update: async (args: { data: Record<string, number> }) => {
       updates.push(args)
       return {}
     },
   }
-  await consumeOrderInventory(payload as any, [{ product: 'p-1', variant: 9 as any, quantity: 1 }])
-  assert.equal(updates.length, 1)
+  await consumeOrderInventory(payload as never, [{ product: 'p1', quantity: 1 } as never])
+  assert.equal(updates[0]?.data.quantity, 0)
+  assert.equal(updates[0]?.data.reservedQuantity, 0)
 })
 
-test('should match stock level when item variant is a string id', async () => {
-  const updates: any[] = []
+test('consumeOrderInventory: legacy uses Number on level quantity and reserved', async () => {
+  const updates: Array<{ data: Record<string, number> }> = []
   const payload = {
     find: async () => ({
       docs: [
         {
-          id: 'sl-s',
-          product: 'p-1',
-          variant: 'v-str',
-          quantity: 4,
-          reservedQuantity: 2,
-        },
-      ],
-    }),
-    update: async (args: any) => {
-      updates.push(args)
-      return {}
-    },
-  }
-  await consumeOrderInventory(payload as any, [
-    { product: 'p-1', variant: 'v-str', quantity: 1 },
-  ])
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].data.quantity, 3)
-})
-
-test('should no-op when items have no resolvable product ids', async () => {
-  let findCalls = 0
-  const payload = {
-    find: async () => {
-      findCalls++
-      return { docs: [] }
-    },
-    update: async () => ({}),
-  }
-  await consumeOrderInventory(payload as any, [{ product: null, quantity: 1 }] as any)
-  assert.equal(findCalls, 0)
-})
-
-test('should match variant and pass req to update when provided', async () => {
-  const updates: any[] = []
-  const payload = {
-    find: async () => ({
-      docs: [
-        {
-          id: 'sl-v',
-          product: { id: 'p-1' },
-          variant: { id: 'v-1' },
+          id: 'sl-lv',
+          product: 'p1',
+          variant: null,
           quantity: 8,
-          reservedQuantity: 2,
+          reservedQuantity: 3,
         },
       ],
     }),
-    update: async (args: any) => {
+    update: async (args: { data: Record<string, number> }) => {
       updates.push(args)
       return {}
     },
   }
-  const req = { user: { id: 'u-1' } } as any
-  await consumeOrderInventory(
-    payload as any,
-    [{ product: { id: 'p-1' }, variant: { id: 'v-1' }, quantity: 1 }],
-    req,
-  )
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].req, req)
-  assert.equal(updates[0].data.quantity, 7)
+  await consumeOrderInventory(payload as never, [{ product: 'p1', quantity: 1 } as never])
+  assert.equal(updates[0]?.data.quantity, 7)
+  assert.equal(updates[0]?.data.reservedQuantity, 2)
+})
+
+test('consumeOrderInventory: legacy passes req on update', async () => {
+  const seen: unknown[] = []
+  const fakeReq = { tag: 'r' }
+  const payload = {
+    find: async () => ({
+      docs: [{ id: 'sl-1', product: 'p1', variant: null, quantity: 4, reservedQuantity: 1 }],
+    }),
+    update: async (args: { req?: unknown }) => {
+      seen.push(args.req)
+      return {}
+    },
+  }
+  await consumeOrderInventory(payload as never, [{ product: 'p1', quantity: 1 } as never], fakeReq as never)
+  assert.equal(seen[0], fakeReq)
 })

--- a/packages/backend/tests/unit/lib/order-item-relation-id.unit.test.ts
+++ b/packages/backend/tests/unit/lib/order-item-relation-id.unit.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import { orderItemRelationId } from '../../../src/lib/order-item-relation-id.ts'
+
+test('returns null for null and undefined', () => {
+  assert.equal(orderItemRelationId(null), null)
+  assert.equal(orderItemRelationId(undefined), null)
+})
+
+test('returns id string for populated object', () => {
+  assert.equal(orderItemRelationId({ id: 'abc' }), 'abc')
+})
+
+test('stringifies plain object without id', () => {
+  assert.equal(orderItemRelationId({}), '[object Object]')
+})
+
+test('stringifies primitive ids', () => {
+  assert.equal(orderItemRelationId('sl-1'), 'sl-1')
+  assert.equal(orderItemRelationId(42), '42')
+})

--- a/packages/backend/tests/unit/lib/release-order-inventory.unit.test.ts
+++ b/packages/backend/tests/unit/lib/release-order-inventory.unit.test.ts
@@ -1,190 +1,305 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 // @ts-ignore
-import { releaseOrderInventory } from '../../../src/lib/release-order-inventory.ts'
+import { releaseOrderInventory, stockLevelIdFromItem } from '../../../src/lib/release-order-inventory.ts'
 
-test('should no-op when items array is empty', async () => {
-  let findCalls = 0
-  const payload = {
-    find: async () => {
-      findCalls++
-      return { docs: [] }
-    },
-    update: async () => ({}),
-  }
-  await releaseOrderInventory(payload as any, [], undefined)
-  assert.equal(findCalls, 0)
+test('stockLevelIdFromItem: null and object', () => {
+  assert.equal(stockLevelIdFromItem({ stockLevel: null }), null)
+  assert.equal(stockLevelIdFromItem({ stockLevel: { id: 'x' } }), 'x')
+  assert.equal(stockLevelIdFromItem({ stockLevel: 'y' }), 'y')
 })
 
-test('should decrement reservedQuantity when matching stock level exists', async () => {
-  const updates: any[] = []
+test('releaseOrderInventory: empty items', async () => {
+  await releaseOrderInventory({} as never, [])
+})
+
+test('releaseOrderInventory: direct path uses quantity 1 when item quantity is zero', async () => {
+  const updates: Array<{ data: { reservedQuantity: number } }> = []
   const payload = {
-    find: async () => ({
-      docs: [
-        {
-          id: 'sl-1',
-          product: 'p-1',
-          variant: null,
-          reservedQuantity: 5,
-        },
-      ],
-    }),
-    update: async (args: any) => {
+    find: async () => ({ docs: [] }),
+    findByID: async () => ({ id: 'sl-1', reservedQuantity: 3 }),
+    update: async (args: { data: { reservedQuantity: number } }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ stockLevel: 'sl-1', quantity: 0, product: 'p1' } as never])
+  assert.equal(updates[0]?.data.reservedQuantity, 2)
+})
+
+test('releaseOrderInventory: direct path coerces missing reservedQuantity', async () => {
+  const updates: Array<{ data: { reservedQuantity: number } }> = []
+  const payload = {
+    find: async () => ({ docs: [] }),
+    findByID: async () => ({ id: 'sl-1', reservedQuantity: undefined }),
+    update: async (args: { data: { reservedQuantity: number } }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ stockLevel: 'sl-1', quantity: 1, product: 'p1' } as never])
+  assert.equal(updates[0]?.data.reservedQuantity, 0)
+})
+
+test('releaseOrderInventory: direct stockLevel decreases reserved only', async () => {
+  const updates: Array<{ id: string; data: { reservedQuantity: number } }> = []
+  const payload = {
+    find: async () => ({ docs: [] }),
+    findByID: async () => ({ id: 'sl-1', reservedQuantity: 10 }),
+    update: async (args: { id: string; data: { reservedQuantity: number } }) => {
       updates.push(args)
       return {}
     },
   }
   await releaseOrderInventory(
-    payload as any,
-    [{ product: 'p-1', quantity: 2 }],
-    {} as any,
+    payload as never,
+    [{ stockLevel: 'sl-1', quantity: 3, product: 'p1' } as never],
+    {} as never,
   )
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].data.reservedQuantity, 3)
+  assert.equal(updates[0]?.data.reservedQuantity, 7)
 })
 
-test('should match variant-specific stock level', async () => {
+test('releaseOrderInventory: skips update when level doc missing', async () => {
+  let updates = 0
+  const payload = {
+    find: async () => ({ docs: [] }),
+    findByID: async () => null,
+    update: async () => {
+      updates++
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ stockLevel: 'gone', quantity: 1, product: 'p1' } as never])
+  assert.equal(updates, 0)
+})
+
+test('releaseOrderInventory: legacy product match', async () => {
+  const updates: Array<{ id: string }> = []
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-r',
+          product: 'p1',
+          variant: null,
+          reservedQuantity: 5,
+        },
+      ],
+    }),
+    update: async (args: { id: string }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ product: 'p1', quantity: 2 } as never])
+  assert.equal(updates[0]?.id, 'sl-r')
+})
+
+test('releaseOrderInventory: all direct stockLevel skips bulk find', async () => {
+  let findCalls = 0
+  const payload = {
+    find: async (args: { collection: string }) => {
+      if (args.collection === 'stock-levels') findCalls++
+      return { docs: [] }
+    },
+    findByID: async () => ({ id: 'sl-1', reservedQuantity: 3 }),
+    update: async () => ({}),
+  }
+  await releaseOrderInventory(payload as never, [
+    { stockLevel: 'sl-1', quantity: 1, product: 'p1' } as never,
+  ])
+  assert.equal(findCalls, 0)
+})
+
+test('releaseOrderInventory: legacy skips without product', async () => {
+  let updates = 0
+  const payload = {
+    find: async () => ({ docs: [] }),
+    update: async () => {
+      updates++
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ quantity: 1 } as never])
+  assert.equal(updates, 0)
+})
+
+test('releaseOrderInventory: legacy matches row with variant stored as object', async () => {
+  const updates: Array<{ id: string }> = []
+  const payload = {
+    find: async () => ({
+      docs: [
+        {
+          id: 'sl-vo',
+          product: 'p1',
+          variant: { id: 'vz' },
+          reservedQuantity: 4,
+        },
+      ],
+    }),
+    update: async (args: { id: string }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ product: 'p1', variant: 'vz', quantity: 1 } as never])
+  assert.equal(updates[0]?.id, 'sl-vo')
+})
+
+test('releaseOrderInventory: legacy variant object id', async () => {
+  const updates: Array<{ id: string }> = []
   const payload = {
     find: async () => ({
       docs: [
         {
           id: 'sl-v',
-          product: 'p-1',
-          variant: 'v-1',
-          reservedQuantity: 1,
+          product: 'p1',
+          variant: 'v-2',
+          reservedQuantity: 4,
         },
       ],
     }),
-    update: async (args: any) => {
-      assert.equal(args.data.reservedQuantity, 0)
+    update: async (args: { id: string }) => {
+      updates.push(args)
       return {}
     },
   }
-  await releaseOrderInventory(
-    payload as any,
-    [{ product: 'p-1', variant: 'v-1', quantity: 1 }],
-    {} as any,
-  )
+  await releaseOrderInventory(payload as never, [
+    { product: 'p1', variant: { id: 'v-2' }, quantity: 1 } as never,
+  ])
+  assert.equal(updates[0]?.id, 'sl-v')
 })
 
-test('should no-op when product ids list is empty', async () => {
-  let findCalls = 0
-  const payload = {
-    find: async () => {
-      findCalls++
-      return { docs: [] }
-    },
-    update: async () => ({}),
-  }
-  await releaseOrderInventory(payload as any, [{ product: undefined, quantity: 1 }] as any)
-  assert.equal(findCalls, 0)
-})
-
-test('should skip update when no stock level matches', async () => {
+test('releaseOrderInventory: legacy no matching row', async () => {
   let updates = 0
   const payload = {
     find: async () => ({
-      docs: [{ id: 'sl-1', product: 'p-2', variant: null, reservedQuantity: 1 }],
+      docs: [{ id: 'x', product: 'p1', variant: 'a', reservedQuantity: 1 }],
     }),
     update: async () => {
       updates++
       return {}
     },
   }
-  await releaseOrderInventory(payload as any, [{ product: 'p-1', quantity: 1 }])
+  await releaseOrderInventory(payload as never, [{ product: 'p1', variant: 'b', quantity: 1 } as never])
   assert.equal(updates, 0)
 })
 
-test('should resolve object product and variant ids and match object stock rows', async () => {
-  const updates: any[] = []
+test('releaseOrderInventory: legacy coerces missing reserved on matched row', async () => {
+  const updates: Array<{ data: { reservedQuantity: number } }> = []
   const payload = {
     find: async () => ({
       docs: [
         {
-          id: 'sl-obj',
-          product: { id: 'p-obj' },
-          variant: { id: 'v-obj' },
-          reservedQuantity: 4,
+          id: 'sl-u',
+          product: 'p1',
+          variant: null,
+          reservedQuantity: undefined,
         },
       ],
     }),
-    update: async (args: any) => {
+    update: async (args: { data: { reservedQuantity: number } }) => {
       updates.push(args)
       return {}
     },
   }
-  await releaseOrderInventory(
-    payload as any,
-    [{ product: { id: 'p-obj' }, variant: { id: 'v-obj' }, quantity: 2 }],
-    undefined,
-  )
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].data.reservedQuantity, 2)
-  assert.equal(updates[0].req, undefined)
+  await releaseOrderInventory(payload as never, [{ product: 'p1', quantity: 1 } as never])
+  assert.equal(updates[0]?.data.reservedQuantity, 0)
 })
 
-test('should skip items without product while still processing others', async () => {
-  const updates: any[] = []
+test('releaseOrderInventory: legacy uses explicit item quantity', async () => {
+  const updates: Array<{ data: { reservedQuantity: number } }> = []
   const payload = {
     find: async () => ({
-      docs: [{ id: 'sl-1', product: 'p-1', variant: null, reservedQuantity: 5 }],
+      docs: [
+        {
+          id: 'sl-q',
+          product: 'p1',
+          variant: null,
+          reservedQuantity: 9,
+        },
+      ],
     }),
-    update: async (args: any) => {
+    update: async (args: { data: { reservedQuantity: number } }) => {
       updates.push(args)
       return {}
     },
   }
-  await releaseOrderInventory(payload as any, [
-    { product: 'p-1', quantity: 1 },
-    { product: undefined, quantity: 99 },
-  ] as any)
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].data.reservedQuantity, 4)
+  await releaseOrderInventory(payload as never, [{ product: 'p1', quantity: 4 } as never])
+  assert.equal(updates[0]?.data.reservedQuantity, 5)
 })
 
-test('should treat falsy quantity as 1 when releasing', async () => {
-  const updates: any[] = []
+test('releaseOrderInventory: legacy coerces NaN item quantity to 1', async () => {
+  const updates: Array<{ data: { reservedQuantity: number } }> = []
   const payload = {
     find: async () => ({
-      docs: [{ id: 'sl-q', product: 'p-q', variant: null, reservedQuantity: 5 }],
+      docs: [
+        {
+          id: 'sl-n',
+          product: 'p1',
+          variant: null,
+          reservedQuantity: 3,
+        },
+      ],
     }),
-    update: async (args: any) => {
+    update: async (args: { data: { reservedQuantity: number } }) => {
       updates.push(args)
       return {}
     },
   }
-  await releaseOrderInventory(payload as any, [{ product: 'p-q', quantity: 0 }])
-  assert.equal(updates.length, 1)
-  assert.equal(updates[0].data.reservedQuantity, 4)
+  await releaseOrderInventory(payload as never, [{ product: 'p1', quantity: Number.NaN } as never])
+  assert.equal(updates[0]?.data.reservedQuantity, 2)
 })
 
-test('should treat missing reservedQuantity on level as zero', async () => {
-  let newReserved: number | undefined
+test('releaseOrderInventory: legacy uses Number on reservedQuantity with explicit value', async () => {
+  const updates: Array<{ data: { reservedQuantity: number } }> = []
   const payload = {
     find: async () => ({
-      docs: [{ id: 'sl-mr', product: 'p-mr', variant: null }],
+      docs: [
+        {
+          id: 'sl-rn',
+          product: 'p1',
+          variant: null,
+          reservedQuantity: 6,
+        },
+      ],
     }),
-    update: async (args: any) => {
-      newReserved = args.data.reservedQuantity
-      return {}
-    },
-  }
-  await releaseOrderInventory(payload as any, [{ product: 'p-mr', quantity: 1 }])
-  assert.equal(newReserved, 0)
-})
-
-test('should match stock level when variant is null on item and stock', async () => {
-  const updates: any[] = []
-  const payload = {
-    find: async () => ({
-      docs: [{ id: 'sl-nv', product: 'p-x', variant: null, reservedQuantity: 1 }],
-    }),
-    update: async (args: any) => {
+    update: async (args: { data: { reservedQuantity: number } }) => {
       updates.push(args)
       return {}
     },
   }
-  const reqCtx = { x: 1 }
-  await releaseOrderInventory(payload as any, [{ product: 'p-x', variant: null, quantity: 1 }], reqCtx as any)
-  assert.equal(updates[0].req, reqCtx)
+  await releaseOrderInventory(payload as never, [{ product: 'p1', quantity: 2 } as never])
+  assert.equal(updates[0]?.data.reservedQuantity, 4)
+})
+
+test('releaseOrderInventory: legacy passes req on update', async () => {
+  const seen: unknown[] = []
+  const fakeReq = { tag: 'lr' }
+  const payload = {
+    find: async () => ({
+      docs: [{ id: 'sl-1', product: 'p1', variant: null, reservedQuantity: 2 }],
+    }),
+    update: async (args: { req?: unknown }) => {
+      seen.push(args.req)
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ product: 'p1', quantity: 1 } as never], fakeReq as never)
+  assert.equal(seen[0], fakeReq)
+})
+
+test('releaseOrderInventory: direct path passes req', async () => {
+  const seen: unknown[] = []
+  const fakeReq = { r: 1 }
+  const payload = {
+    find: async () => ({ docs: [] }),
+    findByID: async () => ({ id: 'sl-1', reservedQuantity: 2 }),
+    update: async (args: { req?: unknown }) => {
+      seen.push(args.req)
+      return {}
+    },
+  }
+  await releaseOrderInventory(payload as never, [{ stockLevel: 'sl-1', quantity: 1, product: 'p' } as never], fakeReq as never)
+  assert.equal(seen[0], fakeReq)
 })

--- a/packages/backend/tests/unit/lib/transfer-stock-reservation.unit.test.ts
+++ b/packages/backend/tests/unit/lib/transfer-stock-reservation.unit.test.ts
@@ -1,0 +1,160 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import { transferStockReservation } from '../../../src/lib/transfer-stock-reservation.ts'
+
+test('transferStockReservation: no-op when quantity < 1', async () => {
+  const payload = { findByID: async () => ({}), update: async () => ({}) }
+  await transferStockReservation(payload as never, { fromStockLevelId: 'a', toStockLevelId: 'b', quantity: 0 })
+})
+
+test('transferStockReservation: no-op when from === to', async () => {
+  const payload = { findByID: async () => ({}), update: async () => ({}) }
+  await transferStockReservation(payload as never, { fromStockLevelId: 'same', toStockLevelId: 'same', quantity: 2 })
+})
+
+test('transferStockReservation: throws when stock level missing', async () => {
+  const payload = {
+    findByID: async (args: { id: string }) => (args.id === 'a' ? null : { id: 'b' }),
+    update: async () => ({}),
+  }
+  await assert.rejects(
+    () =>
+      transferStockReservation(payload as never, { fromStockLevelId: 'a', toStockLevelId: 'b', quantity: 1 }),
+    /Stock level not found/,
+  )
+})
+
+test('transferStockReservation: treats missing reservedQuantity on source as zero', async () => {
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'from'
+        ? { id: 'from', quantity: 100 }
+        : { id: 'to', reservedQuantity: 0, quantity: 50 },
+    update: async () => ({}),
+  }
+  await assert.rejects(
+    () =>
+      transferStockReservation(payload as never, { fromStockLevelId: 'from', toStockLevelId: 'to', quantity: 1 }),
+    /does not hold enough reserved/,
+  )
+})
+
+test('transferStockReservation: treats missing quantity on target as zero capacity', async () => {
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'from'
+        ? { id: 'from', reservedQuantity: 10, quantity: 100 }
+        : { id: 'to', reservedQuantity: 0 },
+    update: async () => ({}),
+  }
+  await assert.rejects(
+    () =>
+      transferStockReservation(payload as never, { fromStockLevelId: 'from', toStockLevelId: 'to', quantity: 3 }),
+    /Insufficient available capacity at target/,
+  )
+})
+
+test('transferStockReservation: throws when source reserved too low', async () => {
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'from'
+        ? { id: 'from', reservedQuantity: 1, quantity: 10 }
+        : { id: 'to', reservedQuantity: 0, quantity: 50 },
+    update: async () => ({}),
+  }
+  await assert.rejects(
+    () =>
+      transferStockReservation(payload as never, { fromStockLevelId: 'from', toStockLevelId: 'to', quantity: 5 }),
+    /does not hold enough reserved/,
+  )
+})
+
+test('transferStockReservation: throws when target available capacity insufficient', async () => {
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'from'
+        ? { id: 'from', reservedQuantity: 10, quantity: 100 }
+        : { id: 'to', reservedQuantity: 9, quantity: 10 },
+    update: async () => ({}),
+  }
+  await assert.rejects(
+    () =>
+      transferStockReservation(payload as never, { fromStockLevelId: 'from', toStockLevelId: 'to', quantity: 3 }),
+    /Insufficient available capacity at target/,
+  )
+})
+
+test('transferStockReservation: allows when source reserved equals quantity exactly', async () => {
+  const updates: Array<{ id: string; data: { reservedQuantity: number } }> = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'from'
+        ? { id: 'from', reservedQuantity: 3, quantity: 100 }
+        : { id: 'to', reservedQuantity: 0, quantity: 10 },
+    update: async (args: { id: string; data: { reservedQuantity: number } }) => {
+      updates.push({ id: args.id, data: args.data })
+      return {}
+    },
+  }
+  await transferStockReservation(payload as never, { fromStockLevelId: 'from', toStockLevelId: 'to', quantity: 3 })
+  assert.equal(updates.length, 2)
+})
+
+test('transferStockReservation: allows when target free capacity equals quantity exactly', async () => {
+  const updates: Array<{ id: string }> = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'from'
+        ? { id: 'from', reservedQuantity: 5, quantity: 100 }
+        : { id: 'to', reservedQuantity: 2, quantity: 7 },
+    update: async (args: { id: string }) => {
+      updates.push(args)
+      return {}
+    },
+  }
+  await transferStockReservation(payload as never, { fromStockLevelId: 'from', toStockLevelId: 'to', quantity: 5 })
+  assert.equal(updates.length, 2)
+})
+
+test('transferStockReservation: updates both rows', async () => {
+  const updates: Array<{ id: string; data: { reservedQuantity: number } }> = []
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'from'
+        ? { id: 'from', reservedQuantity: 5, quantity: 100 }
+        : { id: 'to', reservedQuantity: 1, quantity: 50 },
+    update: async (args: { id: string; data: { reservedQuantity: number } }) => {
+      updates.push({ id: args.id, data: args.data })
+      return {}
+    },
+  }
+  await transferStockReservation(payload as never, { fromStockLevelId: 'from', toStockLevelId: 'to', quantity: 2 })
+  assert.equal(updates.length, 2)
+  assert.deepEqual(
+    updates.find((u) => u.id === 'from')?.data,
+    { reservedQuantity: 3 },
+  )
+  assert.deepEqual(
+    updates.find((u) => u.id === 'to')?.data,
+    { reservedQuantity: 3 },
+  )
+})
+
+test('transferStockReservation: passes req when provided', async () => {
+  const seen: unknown[] = []
+  const fakeReq = { trace: 'x' }
+  const payload = {
+    findByID: async (args: { id: string }) =>
+      args.id === 'f'
+        ? { id: 'f', reservedQuantity: 2, quantity: 10 }
+        : { id: 't', reservedQuantity: 0, quantity: 10 },
+    update: async (args: { req?: unknown }) => {
+      seen.push(args.req)
+      return {}
+    },
+  }
+  await transferStockReservation(payload as never, { fromStockLevelId: 'f', toStockLevelId: 't', quantity: 1 }, fakeReq as never)
+  assert.equal(seen[0], fakeReq)
+  assert.equal(seen[1], fakeReq)
+})


### PR DESCRIPTION
## Overview
Phase 12 delivers **multi-warehouse inventory** on the backend: each order line points at a **`stock-levels`** row for fulfillment, checkout **reserves** stock, cancel **releases**, and ship **consumes**, with behavior aligned for single-vendor and **multivendor** (tenant-scoped locations and access).

## What shipped
- **Allocation:** Deterministic pick of an eligible `stock-levels` row at checkout; **`stockLevel`** stored on **`order-items`**.
- **Inventory math:** **`reservedQuantity`** / **`quantity`** updates in **process-checkout**, **release**, and **consume** paths; legacy lines without `stockLevel` keep previous product/variant matching where applicable.
- **Multivendor:** **`stock-locations`** tenant field when MV is on; access helper for admin vs vendor stock tenant; order splitter passes context used for line creation.
- **Vendor fulfillment:** Vendors may **`PATCH`** only **`stockLevel`** on their lines; **Payload-merged PATCH** bodies are supported (non–`stockLevel` keys must match the stored document). Hook **transfers reservation** between stock rows when the line’s warehouse changes.
- **Tests:** New/extended **unit** tests (allocation, transfer, hooks, consume/release), **security** case for multivendor allocation, **E2E** (SV + MV guest lifecycle, two-warehouse pick + vendor reassignment), harness and runner updates for profiles.
- **Docs (if in this PR):** `PHASE-12-MULTI-WAREHOUSE-INVENTORY.md`, `MANUAL-TEST-INVENTORY.md` (including vendor `PATCH` notes).

## Stats
- **~34 files** in `packages/backend` once all new files are staged (19 modified + 15 new); **~+1404 / −351** lines on currently tracked diffs (plus new file line counts when added).

## How to verify
```bash
cd packages/backend
yarn test:unit:cov
yarn test:all-profiles:safe:parallel:observe   # optional full matrix