### PR TITLE
feat(inventory): PDP variant availability API and optional cart warehouse validation

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -164,6 +164,15 @@ SHIPPING_MODEL=platform
 INVENTORY_ENABLED=true
 LOW_STOCK_THRESHOLD=10
 
+# When true | 1 | yes | on: each cart save validates lines with the same warehouse allocation as checkout
+# (`allocateStockLevelForLine`), using the cart's `store` as `storeLocationId` when present.
+# Default / omit / false: legacy behavior — cart does not reject lines that fail allocation (checkout may still fail).
+# INVENTORY_VALIDATE_CART_LINES=true
+
+# When false | 0 | no | off: `GET /api/storefront/variant-availability` returns 404 (hide PDP probe from public callers).
+# Omit or true: endpoint enabled when inventory feature allows it (see `packages/backend/src/lib/inventory-policy.ts`).
+# STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED=false
+
 # ═══════════════════════════════════════════════════
 # GEOGRAPHY (country → subdivision → locality; stock-location-service-areas)
 # ═══════════════════════════════════════════════════

--- a/packages/backend/migrations/20260507_120000_order_items_product_slug.ts
+++ b/packages/backend/migrations/20260507_120000_order_items_product_slug.ts
@@ -1,0 +1,17 @@
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-postgres'
+
+/**
+ * Immutable PDP slug snapshot at checkout (`order-items.productSlug`).
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "order_items" ADD COLUMN IF NOT EXISTS "product_slug" varchar;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "order_items" DROP COLUMN IF EXISTS "product_slug";
+  `)
+}

--- a/packages/backend/migrations/index.ts
+++ b/packages/backend/migrations/index.ts
@@ -1,6 +1,7 @@
 import * as migration_20260426_095728 from './20260426_095728'
 import * as migration_20260429_140000_cod_collect_and_order_channel from './20260429_140000_cod_collect_and_order_channel'
 import * as migration_20260430_120000_add_carts_customer_note from './20260430_120000_add_carts_customer_note'
+import * as migration_20260507_120000_order_items_product_slug from './20260507_120000_order_items_product_slug'
 
 export const migrations = [
   {
@@ -17,5 +18,10 @@ export const migrations = [
     up: migration_20260430_120000_add_carts_customer_note.up,
     down: migration_20260430_120000_add_carts_customer_note.down,
     name: '20260430_120000_add_carts_customer_note',
+  },
+  {
+    up: migration_20260507_120000_order_items_product_slug.up,
+    down: migration_20260507_120000_order_items_product_slug.down,
+    name: '20260507_120000_order_items_product_slug',
   },
 ]

--- a/packages/backend/src/endpoints/storefront-variant-availability.ts
+++ b/packages/backend/src/endpoints/storefront-variant-availability.ts
@@ -1,0 +1,118 @@
+/**
+ * GET /api/storefront/variant-availability?product={id}&store={stockLocationId?}
+ *
+ * Public read model for PDP: which variant lines can be allocated at least one unit
+ * using the same rules as checkout (`allocateStockLevelForLine`).
+ *
+ * Gated by `STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED`. Response includes `inventoryEnabled`
+ * reflecting `INVENTORY_ENABLED` (when disabled, all lines are `purchasable: true` without allocation work).
+ */
+import type { Endpoint } from 'payload'
+import { allocateStockLevelForLine } from '../lib/allocate-stock-level'
+import {
+  isInventoryEnabled,
+  isStorefrontVariantAvailabilityEndpointEnabled,
+} from '../lib/inventory-policy'
+
+export const storefrontVariantAvailabilityEndpoint: Endpoint = {
+  path: '/storefront/variant-availability',
+  method: 'get',
+  handler: async (req) => {
+    if (!isStorefrontVariantAvailabilityEndpointEnabled()) {
+      return Response.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    const url = new URL(req.url ?? '', 'http://localhost')
+    const productId = url.searchParams.get('product')?.trim()
+    const storeId = url.searchParams.get('store')?.trim() || undefined
+
+    if (!productId) {
+      return Response.json({ error: 'product query parameter is required' }, { status: 400 })
+    }
+
+    try {
+      const product = await req.payload.findByID({
+        collection: 'products',
+        id: productId,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      if (!product || (product as { status?: string }).status !== 'published') {
+        return Response.json({ error: 'Product not found' }, { status: 404 })
+      }
+
+      const multivendor = process.env.MULTIVENDOR_ENABLED === 'true'
+      const tenantRaw = (product as { tenant?: { id: string } | string | null }).tenant
+      let tenantId: string | null = null
+      if (multivendor && tenantRaw != null) {
+        tenantId = typeof tenantRaw === 'object' ? tenantRaw?.id ?? null : String(tenantRaw)
+      }
+
+      const { docs: variantDocs } = await req.payload.find({
+        collection: 'product-variants',
+        where: {
+          and: [{ product: { equals: productId } }, { isActive: { equals: true } }],
+        },
+        limit: 200,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      if (!isInventoryEnabled()) {
+        return Response.json({
+          inventoryEnabled: false,
+          productId,
+          storeLocationId: storeId ?? null,
+          lines: variantDocs.map((v) => ({
+            variantId: String(v.id),
+            purchasable: true,
+          })),
+        })
+      }
+
+      const lines: Array<{ variantId: string | null; purchasable: boolean }> = []
+
+      for (const v of variantDocs) {
+        const vid = String(v.id)
+        const r = await allocateStockLevelForLine(
+          req.payload,
+          {
+            productId,
+            variantId: vid,
+            quantity: 1,
+            tenantId,
+            storeLocationId: storeId ?? null,
+          },
+          req,
+        )
+        lines.push({ variantId: vid, purchasable: !('error' in r) })
+      }
+
+      if (variantDocs.length === 0) {
+        const r = await allocateStockLevelForLine(
+          req.payload,
+          {
+            productId,
+            variantId: null,
+            quantity: 1,
+            tenantId,
+            storeLocationId: storeId ?? null,
+          },
+          req,
+        )
+        lines.push({ variantId: null, purchasable: !('error' in r) })
+      }
+
+      return Response.json({
+        inventoryEnabled: true,
+        productId,
+        storeLocationId: storeId ?? null,
+        lines,
+      })
+    } catch (err) {
+      console.error('[storefront/variant-availability]', err)
+      return Response.json({ error: 'Failed to resolve availability' }, { status: 500 })
+    }
+  },
+}

--- a/packages/backend/src/lib/inventory-policy.ts
+++ b/packages/backend/src/lib/inventory-policy.ts
@@ -1,0 +1,42 @@
+/**
+ * Central inventory behaviour for cart vs checkout (Phase 12).
+ * Deployments toggle stock enforcement via env without duplicated semantics.
+ */
+
+/** Master switch: when false, checkout skips allocation and carts skip warehouse checks. */
+export function isInventoryEnabled(): boolean {
+  return process.env.INVENTORY_ENABLED !== 'false'
+}
+
+function parseEnvBool(raw: string | undefined, defaultValue: boolean): boolean {
+  if (raw === undefined || raw.trim() === '') return defaultValue
+  const v = raw.trim().toLowerCase()
+  if (v === 'false' || v === '0' || v === 'no' || v === 'off') return false
+  if (v === 'true' || v === '1' || v === 'yes' || v === 'on') return true
+  return defaultValue
+}
+
+/**
+ * When true with {@link isInventoryEnabled}, each cart save runs the same warehouse allocation
+ * rules as checkout (`allocateStockLevelForLine`). Prevents lines that would fail at payment.
+ *
+ * Default **false** so existing installs/tests without stock rows keep cart PATCH behaviour until opted in.
+ * Set `INVENTORY_VALIDATE_CART_LINES=true` for strict storefronts.
+ */
+export function shouldValidateCartWarehouseAllocation(): boolean {
+  if (!isInventoryEnabled()) return false
+  return parseEnvBool(process.env.INVENTORY_VALIDATE_CART_LINES, false)
+}
+
+/** Single-store cart mode (narrow validation to one stock-location). */
+export function isSingleStoreCartEnabled(): boolean {
+  return process.env.SINGLE_STORE_CART_ENABLED === 'true'
+}
+
+/**
+ * Public GET `/api/storefront/variant-availability` — disable when you do not want storefront
+ * probing warehouse rows (default on).
+ */
+export function isStorefrontVariantAvailabilityEndpointEnabled(): boolean {
+  return parseEnvBool(process.env.STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED, true)
+}

--- a/packages/backend/src/lib/process-checkout.ts
+++ b/packages/backend/src/lib/process-checkout.ts
@@ -382,6 +382,9 @@ export async function processCheckout(
 
     const productNameSnapshot = resolveLocalizedText(productAny.name, checkoutLocale) || 'Product'
 
+    const slugRaw = (product as { slug?: unknown }).slug
+    const productSlugSnapshot = typeof slugRaw === 'string' ? slugRaw.trim() : ''
+
     let productImage = snapshotProductImageUrl(productAny as Record<string, unknown>)
     if (!productImage && productAny.images?.[0]?.image) {
       const imgRef = productAny.images[0].image
@@ -413,6 +416,7 @@ export async function processCheckout(
 
     orderItemData.push({
       productId: productId as string,
+      productSlug: productSlugSnapshot,
       variantId: variantId as string | null,
       productName: productNameSnapshot,
       variantName,
@@ -608,6 +612,7 @@ export async function processCheckout(
             subOrder: subOrder.id,
             tenant: seg.tenantId,
             product: d.productId,
+            productSlug: d.productSlug,
             productName: d.productName,
             variantName: d.variantName,
             sku: d.sku,
@@ -645,6 +650,7 @@ export async function processCheckout(
         const itemData: Record<string, unknown> = {
           order: orderId,
           product: d.productId,
+          productSlug: d.productSlug,
           productName: d.productName,
           variantName: d.variantName,
           sku: d.sku,
@@ -670,6 +676,7 @@ export async function processCheckout(
         const itemData: Record<string, unknown> = {
           order: orderId,
           product: d.productId,
+          productSlug: d.productSlug,
           productName: d.productName,
           variantName: d.variantName,
           sku: d.sku,

--- a/packages/backend/src/payload.config.ts
+++ b/packages/backend/src/payload.config.ts
@@ -45,6 +45,7 @@ import { customEndpointsOpenApiEndpoint } from './endpoints/custom-endpoints-ope
 import { docsIndexEndpoint } from './endpoints/docs-index'
 import { openapiAllEndpoint } from './endpoints/openapi-all'
 import { storefrontStoreProductsEndpoint } from './endpoints/storefront-store-products'
+import { storefrontVariantAvailabilityEndpoint } from './endpoints/storefront-variant-availability'
 import { storefrontGeographyEndpoint } from './endpoints/storefront-geography'
 import { geographyPlugin } from './plugins/geography'
 import { migrations } from '../migrations'
@@ -159,6 +160,7 @@ export default buildConfig({
     openapiAllEndpoint,
     docsIndexEndpoint,
     storefrontStoreProductsEndpoint,
+    storefrontVariantAvailabilityEndpoint,
     storefrontGeographyEndpoint,
   ],
 

--- a/packages/backend/src/plugins/ecommerce/collections/carts.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/carts.ts
@@ -1,4 +1,10 @@
 import { APIError, type CollectionConfig, type Where } from 'payload'
+import { allocateStockLevelForLine } from '../../../lib/allocate-stock-level'
+import {
+  shouldValidateCartWarehouseAllocation,
+  isInventoryEnabled,
+  isSingleStoreCartEnabled,
+} from '../../../lib/inventory-policy'
 import { validateCouponForSubtotal } from '../../discounts/lib/coupon'
 import { isValidUUID } from '../../../lib/utils'
 
@@ -109,6 +115,14 @@ export function createCartsConfig(multivendorEnabled: boolean, allowGuestCheckou
 
         if (!data.items || !Array.isArray(data.items)) return data
 
+        const validateWarehouseOnCart = shouldValidateCartWarehouseAllocation()
+        const warehouseStockLines: Array<{
+          productId: string
+          variantId: string | null
+          tenantId: string | null
+          quantity: number
+        }> = []
+
         // Derive unitPrice and vendor from product/variant — never trust client (OWASP: price manipulation)
         for (const item of data.items) {
           const variantId = typeof item.variant === 'object' ? item.variant?.id : item.variant
@@ -147,43 +161,91 @@ export function createCartsConfig(multivendorEnabled: boolean, allowGuestCheckou
               item.vendor = typeof tenant === 'object' ? tenant?.id : tenant
             }
           }
+
+          if (validateWarehouseOnCart) {
+            const multivendor = process.env.MULTIVENDOR_ENABLED === 'true'
+            const tenantRaw = (product as { tenant?: { id: string } | string | null }).tenant
+            let tenantId: string | null = null
+            if (multivendor && tenantRaw != null) {
+              tenantId = typeof tenantRaw === 'object' ? tenantRaw?.id ?? null : String(tenantRaw)
+            }
+            warehouseStockLines.push({
+              productId: String(productId),
+              variantId: variantId ? String(variantId) : null,
+              tenantId,
+              quantity: Number(item.quantity) || 1,
+            })
+          }
         }
 
-        // ── Single-store cart enforcement ──────────────────────────────────────
-        const singleStoreEnabled = process.env.SINGLE_STORE_CART_ENABLED === 'true'
-        const inventoryEnabled = process.env.INVENTORY_ENABLED !== 'false'
+        const inventoryEnabled = isInventoryEnabled()
+        const singleStoreEnabled = isSingleStoreCartEnabled()
         const storeId = typeof data.store === 'object' ? (data.store as { id: string })?.id : data.store
 
-        if (singleStoreEnabled && inventoryEnabled && storeId) {
+        if (validateWarehouseOnCart) {
+          const storeLocationId = storeId ?? undefined
+          for (const line of warehouseStockLines) {
+            const alloc = await allocateStockLevelForLine(
+              req.payload,
+              {
+                productId: line.productId,
+                variantId: line.variantId,
+                quantity: line.quantity,
+                tenantId: line.tenantId,
+                storeLocationId: storeLocationId ?? null,
+              },
+              req,
+            )
+            if ('error' in alloc) {
+              throw new APIError(alloc.error, 400)
+            }
+          }
+        }
+
+        // ── Single-store cart enforcement (legacy path when warehouse cart validation is off) ──
+        if (!validateWarehouseOnCart && singleStoreEnabled && inventoryEnabled && storeId) {
           for (const item of data.items) {
             const pId = typeof item.product === 'object' ? item.product?.id : item.product
             const vId = item.variant ? (typeof item.variant === 'object' ? item.variant?.id : item.variant) : null
             if (!pId) continue
 
-            const stockWhere: Record<string, unknown> = {
-              and: [
-                { 'location': { equals: storeId } },
-                { product: { equals: pId } },
-              ],
+            const baseAnd: Array<Record<string, unknown>> = [
+              { location: { equals: storeId } },
+              { product: { equals: pId } },
+            ]
+
+            const fetchStockDoc = async (extra: Record<string, unknown> | null) => {
+              const and = extra ? [...baseAnd, extra] : [...baseAnd]
+              const { docs } = await req.payload.find({
+                collection: 'stock-levels',
+                where: { and } as Where,
+                limit: 1,
+                depth: 0,
+                overrideAccess: true,
+              })
+              return docs[0] as { quantity?: number; reservedQuantity?: number } | undefined
             }
+
+            /** Prefer variant-specific rows; fall back to product-level stock (variant unset/null per inventory docs). */
+            let stockRow: { quantity?: number; reservedQuantity?: number } | undefined
             if (vId) {
-              (stockWhere.and as Array<Record<string, unknown>>).push({ variant: { equals: vId } })
+              stockRow = await fetchStockDoc({ variant: { equals: vId } })
+              if (!stockRow) {
+                stockRow = await fetchStockDoc({ variant: { equals: null } })
+              }
+            } else {
+              stockRow = await fetchStockDoc({ variant: { equals: null } })
+              if (!stockRow) {
+                stockRow = await fetchStockDoc(null)
+              }
             }
 
-            const { docs: stockRows } = await req.payload.find({
-              collection: 'stock-levels',
-              where: stockWhere as any,
-              limit: 1,
-              depth: 0,
-              overrideAccess: true,
-            })
-
-            if (stockRows.length === 0) {
+            if (!stockRow) {
               const productName = typeof item.product === 'object' ? (item.product as { name?: string }).name || pId : pId
               throw new APIError(`Product "${productName}" is not available at the selected store`, 400)
             }
 
-            const sl = stockRows[0] as { quantity?: number; reservedQuantity?: number }
+            const sl = stockRow
             const available = (Number(sl.quantity) || 0) - (Number(sl.reservedQuantity) || 0)
             const qty = Number(item.quantity) || 1
             if (available < qty) {

--- a/packages/backend/src/plugins/ecommerce/collections/product-variants.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/product-variants.ts
@@ -1,6 +1,114 @@
-import type { CollectionBeforeValidateHook, CollectionConfig } from 'payload'
+import { randomBytes } from 'node:crypto'
+import type { CollectionBeforeValidateHook, CollectionConfig, Payload } from 'payload'
 import { isAdmin } from '../../../access/is-admin'
 import { isAdminOrVendorOwner } from '../../../access/is-admin-or-vendor-owner'
+
+function sanitizeSkuPart(raw: string, maxLen: number): string {
+  const s = raw
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, maxLen)
+  return s.length > 0 ? s.toUpperCase() : 'X'
+}
+
+async function isVariantSkuTaken(
+  payload: Payload,
+  sku: string,
+  excludeVariantId?: string | number | null,
+): Promise<boolean> {
+  const { docs } = await payload.find({
+    collection: 'product-variants',
+    where: { sku: { equals: sku } },
+    limit: 5,
+    depth: 0,
+    overrideAccess: true,
+  })
+  if (docs.length === 0) return false
+  if (
+    docs.length === 1 &&
+    excludeVariantId != null &&
+    String(docs[0].id) === String(excludeVariantId)
+  ) {
+    return false
+  }
+  return true
+}
+
+async function generateUniqueVariantSku(args: {
+  payload: Payload
+  productId: string
+  variantName: string
+  excludeVariantId?: string | number | null
+}): Promise<string> {
+  const { payload, productId, variantName, excludeVariantId } = args
+
+  const product = await payload.findByID({
+    collection: 'products',
+    id: productId,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  const slugFromProduct =
+    product &&
+    typeof product === 'object' &&
+    product !== null &&
+    'slug' in product &&
+    typeof (product as Record<string, unknown>).slug === 'string'
+      ? String((product as Record<string, unknown>).slug).trim()
+      : ''
+  const slugRaw = slugFromProduct.length > 0 ? slugFromProduct : String(productId)
+
+  const base = sanitizeSkuPart(slugRaw, 48)
+  const namePart = sanitizeSkuPart(variantName || 'V', 32)
+
+  for (let attempt = 0; attempt < 16; attempt++) {
+    const entropy =
+      attempt === 0 ? '' : `-${randomBytes(3).toString('hex').toUpperCase()}`
+    const candidate = `${base}-${namePart}${entropy}`.replace(/-+/g, '-').slice(0, 96)
+
+    if (!(await isVariantSkuTaken(payload, candidate, excludeVariantId))) {
+      return candidate
+    }
+  }
+
+  return `${base}-${randomBytes(8).toString('hex').toUpperCase()}`.slice(0, 96)
+}
+
+/** Admin placeholder copy promises auto-generated SKU when left blank — enforce here. */
+const ensureVariantSkuAutofill: CollectionBeforeValidateHook = async ({
+  data,
+  req,
+  originalDoc,
+}) => {
+  if (!data || typeof data !== 'object') return data
+  const d = data as Record<string, unknown>
+  const skuVal = d.sku
+  const skuMissing = skuVal == null || (typeof skuVal === 'string' && skuVal.trim() === '')
+  if (!skuMissing) return data
+
+  const productRef = d.product
+  const productId =
+    typeof productRef === 'object' && productRef && 'id' in productRef
+      ? String((productRef as { id: string }).id)
+      : productRef != null
+        ? String(productRef)
+        : null
+
+  if (!productId || !req.payload) return data
+
+  const name = typeof d.name === 'string' && d.name.trim() ? d.name.trim() : 'Variant'
+
+  d.sku = await generateUniqueVariantSku({
+    payload: req.payload,
+    productId,
+    variantName: name,
+    excludeVariantId: originalDoc?.id ?? null,
+  })
+  return data
+}
 
 /** Existing rows may have NULL before schema sync; default matches Payload `defaultValue`. */
 const ensureVariantSaleDisplayMode: CollectionBeforeValidateHook = ({ data }) => {
@@ -112,6 +220,7 @@ export function createProductVariantsConfig(multivendorEnabled = false): Collect
     hooks: {
       beforeValidate: [
         ensureVariantSaleDisplayMode,
+        ensureVariantSkuAutofill,
         ...(multivendorEnabled ? [inheritTenantFromProductOnVariant] : []),
       ],
     },

--- a/packages/backend/src/plugins/orders/collections/order-items.ts
+++ b/packages/backend/src/plugins/orders/collections/order-items.ts
@@ -104,6 +104,14 @@ export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig
       admin: { description: 'Snapshot at time of purchase.' },
     },
     {
+      name: 'productSlug',
+      type: 'text',
+      admin: {
+        description:
+          'Product URL slug at checkout (immutable). Used for PDP links when the live product slug changes.',
+      },
+    },
+    {
       name: 'itemLabel',
       type: 'text',
       admin: {
@@ -150,7 +158,7 @@ export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig
         : ['order', 'productName', 'variantName', 'stockLevel', 'quantity', 'unitPrice', 'totalPrice'],
       group: 'Orders',
       description:
-        'Line items for an order. Created at checkout from cart. Commercial snapshots (title, SKU, price, qty) are immutable after create; admins may still change stock level for fulfillment routing. Shipping address, store, and totals live on the parent order / sub-order.',
+        'Line items for an order. Created at checkout from cart. Commercial snapshots (title, product slug at checkout, SKU, price, qty) are immutable after create; admins may still change stock level for fulfillment routing. Shipping address, store, and totals live on the parent order / sub-order.',
     },
     access: {
       create: isAdmin,
@@ -166,6 +174,7 @@ export function createOrderItemsConfig(splitByVendor: boolean): CollectionConfig
           if (operation !== 'update' || !data || !originalDoc) return data
           const snapFields: string[] = [
             'productName',
+            'productSlug',
             'variantName',
             'sku',
             'unitPrice',

--- a/packages/backend/src/plugins/orders/strategies/order-splitter.ts
+++ b/packages/backend/src/plugins/orders/strategies/order-splitter.ts
@@ -5,6 +5,8 @@
 
 export interface CartItemForSplit {
   productId: string
+  /** Product `slug` at checkout — persisted on order-items for stable PDP links. */
+  productSlug: string
   variantId: string | null
   productName: string
   variantName: string

--- a/packages/backend/tests/unit/checkout/process-checkout.unit.test.ts
+++ b/packages/backend/tests/unit/checkout/process-checkout.unit.test.ts
@@ -30,7 +30,7 @@ afterEach(() => { for (const k of envKeys) { if (envBackups[k] === undefined) de
 
 function buildPayload(overrides: Record<string, Function> = {}) {
   const calls: Record<string, any[]> = { find: [], findByID: [], create: [], update: [], delete: [] }
-  const defaultProduct = { id: 'prod-1', name: 'Test', basePrice: 50, tenant: null }
+  const defaultProduct = { id: 'prod-1', name: 'Test', slug: 'test-product', basePrice: 50, tenant: null }
 
   return {
     find: async (args: any) => {
@@ -103,6 +103,20 @@ function guestReq() {
     context: {},
   } as any
 }
+
+test('should persist productSlug snapshot on order-items when product has slug', async () => {
+  const payload = buildPayload()
+  const result = await processCheckout(
+    payload,
+    { ...baseInput, guestEmail: 'slug@test.com' },
+    undefined,
+    guestReq(),
+  )
+  assert.equal(result.error, undefined)
+  const itemCreates = payload._calls.create.filter((c: any) => c.collection === 'order-items')
+  assert.equal(itemCreates.length, 1)
+  assert.equal(itemCreates[0].data.productSlug, 'test-product')
+})
 
 test('should return error when guest has neither email nor qualifying phone', async () => {
   const payload = buildPayload()

--- a/packages/backend/tests/unit/collections/cart-store-enforcement.unit.test.ts
+++ b/packages/backend/tests/unit/collections/cart-store-enforcement.unit.test.ts
@@ -183,6 +183,54 @@ test('should reject when stock is insufficient at selected store', async () => {
   process.env.MULTIVENDOR_ENABLED = prevMv
 })
 
+test('should pass when line has variant but inventory row is product-level only at selected store', async () => {
+  const prev = process.env.SINGLE_STORE_CART_ENABLED
+  const prevInv = process.env.INVENTORY_ENABLED
+  const prevMv = process.env.MULTIVENDOR_ENABLED
+  process.env.SINGLE_STORE_CART_ENABLED = 'true'
+  process.env.INVENTORY_ENABLED = 'true'
+  process.env.MULTIVENDOR_ENABLED = 'false'
+
+  const config = createCartsConfig(false)
+  const hook = getBeforeChangeHook(config)
+
+  const data = {
+    items: [{ product: 'p1', variant: 'var-1', quantity: 1 }],
+    store: 'store-ok',
+  }
+
+  const req = {
+    user: { id: 'user-1', role: 'customer' },
+    headers: { get: () => null },
+    payload: {
+      findByID: async (args: { collection: string }) => {
+        if (args.collection === 'products') return { id: 'p1', basePrice: 10, name: 'Widget' }
+        if (args.collection === 'product-variants') return { id: 'var-1', price: 10, product: 'p1' }
+        return {}
+      },
+      find: async (args: { where?: { and?: Array<Record<string, unknown>> } }) => {
+        const and = args.where?.and ?? []
+        const variantClause = and.find((c) => 'variant' in c) as { variant?: { equals?: string | null } } | undefined
+        const variantEquals = variantClause?.variant?.equals
+        if (variantEquals === 'var-1') {
+          return { docs: [] }
+        }
+        if (variantEquals === null) {
+          return { docs: [{ quantity: 100, reservedQuantity: 0 }] }
+        }
+        return { docs: [] }
+      },
+    },
+  }
+
+  const result = await hook({ data, req, operation: 'update' })
+  assert.ok(result, 'hook should fall back to product-level stock when variant-specific row is missing')
+
+  process.env.SINGLE_STORE_CART_ENABLED = prev
+  process.env.INVENTORY_ENABLED = prevInv
+  process.env.MULTIVENDOR_ENABLED = prevMv
+})
+
 test('should pass when product has sufficient stock at selected store', async () => {
   const prev = process.env.SINGLE_STORE_CART_ENABLED
   const prevInv = process.env.INVENTORY_ENABLED

--- a/packages/backend/tests/unit/collections/carts-hooks-inventory-validate.unit.test.ts
+++ b/packages/backend/tests/unit/collections/carts-hooks-inventory-validate.unit.test.ts
@@ -1,0 +1,110 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import { createCartsConfig } from '../../../src/plugins/ecommerce/collections/carts.ts'
+
+function mockHeaders(values: Record<string, string>) {
+  return {
+    get: (name: string) => values[name.toLowerCase()] ?? null,
+  }
+}
+
+function getBeforeChangeHook() {
+  const cfg = createCartsConfig(false, true)
+  const hook = cfg.hooks?.beforeChange?.[0]
+  assert.ok(hook)
+  return hook as any
+}
+
+let backups: Record<string, string | undefined> = {}
+beforeEach(() => {
+  backups = {
+    INVENTORY_ENABLED: process.env.INVENTORY_ENABLED,
+    INVENTORY_VALIDATE_CART_LINES: process.env.INVENTORY_VALIDATE_CART_LINES,
+    MULTIVENDOR_ENABLED: process.env.MULTIVENDOR_ENABLED,
+  }
+})
+afterEach(() => {
+  for (const [k, v] of Object.entries(backups)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+})
+
+test('should reject cart save when INVENTORY_VALIDATE_CART_LINES and allocation fails', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
+  process.env.INVENTORY_VALIDATE_CART_LINES = 'true'
+  process.env.MULTIVENDOR_ENABLED = 'false'
+
+  const hook = getBeforeChangeHook()
+  const data = { items: [{ product: 'p-1', variant: 'v-1', quantity: 1 }] } as any
+
+  let stockFind = 0
+  const req = {
+    user: { id: 'u-1', role: 'customer' },
+    headers: mockHeaders({}),
+    payload: {
+      findByID: async ({ collection }: any) => {
+        if (collection === 'products') return { id: 'p-1', basePrice: 10, tenant: null }
+        if (collection === 'product-variants') {
+          return { id: 'v-1', price: 5, product: 'p-1' }
+        }
+        return null
+      },
+      find: async (args: any) => {
+        if (args.collection === 'stock-levels') {
+          stockFind++
+          return {
+            docs: [],
+            totalDocs: 0,
+          }
+        }
+        return { docs: [], totalDocs: 0 }
+      },
+    },
+  }
+
+  await assert.rejects(() => hook({ operation: 'update', data, req }), /stock configured|warehouse/i)
+  assert.ok(stockFind >= 1)
+})
+
+test('should allow cart save when warehouse allocation succeeds under validate flag', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
+  process.env.INVENTORY_VALIDATE_CART_LINES = 'true'
+  process.env.MULTIVENDOR_ENABLED = 'false'
+
+  const hook = getBeforeChangeHook()
+  const data = { items: [{ product: 'p-1', quantity: 1 }] } as any
+
+  const req = {
+    user: { id: 'u-1', role: 'customer' },
+    headers: mockHeaders({}),
+    payload: {
+      findByID: async ({ collection }: any) => {
+        if (collection === 'products') return { id: 'p-1', basePrice: 10, tenant: null }
+        return null
+      },
+      find: async (args: any) => {
+        if (args.collection === 'stock-levels') {
+          return {
+            docs: [
+              {
+                id: 'sl-1',
+                product: 'p-1',
+                variant: null,
+                quantity: 50,
+                reservedQuantity: 0,
+                location: { id: 'loc-1', tenant: null },
+              },
+            ],
+            totalDocs: 1,
+          }
+        }
+        return { docs: [], totalDocs: 0 }
+      },
+    },
+  }
+
+  const result = await hook({ operation: 'update', data, req })
+  assert.equal(result.items[0].unitPrice, 10)
+})

--- a/packages/backend/tests/unit/collections/carts-hooks.unit.test.ts
+++ b/packages/backend/tests/unit/collections/carts-hooks.unit.test.ts
@@ -43,12 +43,17 @@ function couponRow(overrides: Record<string, unknown> = {}) {
 }
 
 let mvBackup: string | undefined
+let invCartValidateBackup: string | undefined
 beforeEach(() => {
   mvBackup = process.env.MULTIVENDOR_ENABLED
+  invCartValidateBackup = process.env.INVENTORY_VALIDATE_CART_LINES
+  process.env.INVENTORY_VALIDATE_CART_LINES = 'false'
 })
 afterEach(() => {
   if (mvBackup === undefined) delete process.env.MULTIVENDOR_ENABLED
   else process.env.MULTIVENDOR_ENABLED = mvBackup
+  if (invCartValidateBackup === undefined) delete process.env.INVENTORY_VALIDATE_CART_LINES
+  else process.env.INVENTORY_VALIDATE_CART_LINES = invCartValidateBackup
 })
 
 test('beforeChange should return when data is falsy', async () => {

--- a/packages/backend/tests/unit/collections/order-items-hooks.unit.test.ts
+++ b/packages/backend/tests/unit/collections/order-items-hooks.unit.test.ts
@@ -68,6 +68,21 @@ test('access read: customer scoped to own orders when multivendor', () => {
   assert.ok(cust?.order?.customer?.equals === 'c-1')
 })
 
+test('beforeChange[0]: rejects productSlug changes on update', () => {
+  const cfg = createOrderItemsConfig(false)
+  const hook = cfg.hooks?.beforeChange?.[0] as any
+  assert.throws(
+    () =>
+      hook({
+        operation: 'update',
+        data: { productSlug: 'hijacked' },
+        originalDoc: { id: 'oi-1', productSlug: 'widget', productName: 'Widget' },
+        req: { user: { role: 'admin' } },
+      }),
+    /Order line snapshots cannot be changed/,
+  )
+})
+
 test('beforeChange[0]: rejects snapshot field changes on update', () => {
   const cfg = createOrderItemsConfig(true)
   const hook = cfg.hooks?.beforeChange?.[0] as any

--- a/packages/backend/tests/unit/collections/product-variants-hooks.unit.test.ts
+++ b/packages/backend/tests/unit/collections/product-variants-hooks.unit.test.ts
@@ -3,13 +3,21 @@ import assert from 'node:assert/strict'
 // @ts-ignore
 import { createProductVariantsConfig } from '../../../src/plugins/ecommerce/collections/product-variants.ts'
 
-/** Multivendor tenant inheritance is the second beforeValidate hook (after ensureVariantSaleDisplayMode). */
+/** Multivendor tenant inheritance runs after sale display + SKU autofill beforeValidate hooks. */
 function getInheritTenantBeforeValidateHook() {
   const cfg = createProductVariantsConfig(true)
   const hooks = cfg.hooks?.beforeValidate
-  assert.ok(hooks && hooks.length >= 2, 'sale display + inherit-tenant beforeValidate hooks when multivendor')
-  const hook = hooks[1]
+  assert.ok(hooks && hooks.length >= 3, 'sale display + sku + inherit-tenant beforeValidate hooks when multivendor')
+  const hook = hooks[2]
   return hook as (args: { data: any; req: any }) => Promise<any>
+}
+
+function getSkuAutofillBeforeValidateHook() {
+  const cfg = createProductVariantsConfig(false)
+  const hooks = cfg.hooks?.beforeValidate
+  assert.ok(hooks && hooks.length >= 2, 'sale display + sku beforeValidate hooks')
+  const hook = hooks[1]
+  return hook as (args: { data: any; req: any; originalDoc?: any }) => Promise<any>
 }
 
 test('beforeValidate should return early when data is null', async () => {
@@ -83,7 +91,58 @@ test('should set tenant from vendor user when tenant id is a plain string', asyn
 test('should not inject multivendor tenant hook when multivendor is disabled', () => {
   const cfg = createProductVariantsConfig(false)
   const list = cfg.hooks?.beforeValidate
-  assert.equal(list?.length, 1, 'only global hooks (e.g. sale display), no inherit-tenant')
+  assert.equal(list?.length, 2, 'sale display + sku autofill; no inherit-tenant')
+})
+
+test('should generate SKU when missing and product has slug', async () => {
+  const hook = getSkuAutofillBeforeValidateHook()
+  const data = { product: 'prod-slug', name: 'Large Blue', price: 10 } as any
+  const req = {
+    payload: {
+      findByID: async ({ collection, id }: any) => {
+        if (collection === 'products' && id === 'prod-slug') {
+          return { id: 'prod-slug', slug: 'cool-widget' }
+        }
+        return null
+      },
+      find: async () => ({ docs: [] }),
+    },
+    user: { role: 'admin' },
+  }
+  const out = await hook({ data: { ...data }, req })
+  assert.match(out.sku as string, /^COOL-WIDGET-LARGE-BLUE$/i)
+})
+
+test('should not overwrite explicit SKU', async () => {
+  const hook = getSkuAutofillBeforeValidateHook()
+  const data = { product: 'p1', name: 'V', sku: 'KEEP-ME', price: 1 } as any
+  const req = {
+    payload: {
+      findByID: async () => ({ id: 'p1', slug: 'x' }),
+      find: async () => ({ docs: [] }),
+    },
+    user: { role: 'admin' },
+  }
+  const out = await hook({ data: { ...data }, req })
+  assert.equal(out.sku, 'KEEP-ME')
+})
+
+test('should append entropy when SKU collides', async () => {
+  const hook = getSkuAutofillBeforeValidateHook()
+  const data = { product: 'p1', name: 'Dup', price: 2 } as any
+  let findCalls = 0
+  const req = {
+    payload: {
+      findByID: async () => ({ id: 'p1', slug: 'item' }),
+      find: async () => {
+        findCalls += 1
+        return findCalls === 1 ? { docs: [{ id: 'other-var', sku: 'ITEM-DUP' }] } : { docs: [] }
+      },
+    },
+    user: { role: 'admin' },
+  }
+  const out = await hook({ data: { ...data }, req })
+  assert.match(out.sku as string, /^ITEM-DUP-[A-F0-9]{6}$/)
 })
 
 test('read: logged-in customer sees active variants only when multivendor off', () => {

--- a/packages/backend/tests/unit/endpoints/storefront-variant-availability.unit.test.ts
+++ b/packages/backend/tests/unit/endpoints/storefront-variant-availability.unit.test.ts
@@ -1,0 +1,211 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import { storefrontVariantAvailabilityEndpoint } from '../../../src/endpoints/storefront-variant-availability.ts'
+
+let backups: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  backups = {
+    STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED:
+      process.env.STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED,
+    INVENTORY_ENABLED: process.env.INVENTORY_ENABLED,
+    INVENTORY_VALIDATE_CART_LINES: process.env.INVENTORY_VALIDATE_CART_LINES,
+    MULTIVENDOR_ENABLED: process.env.MULTIVENDOR_ENABLED,
+  }
+  process.env.STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED = 'true'
+  process.env.MULTIVENDOR_ENABLED = 'false'
+})
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(backups)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+})
+
+function handlerReq(
+  query: string,
+  payload: { findByID: (args: Record<string, unknown>) => Promise<unknown>; find: (args: Record<string, unknown>) => Promise<{ docs: unknown[] }> },
+) {
+  return {
+    url: `http://localhost/api/storefront/variant-availability?${query}`,
+    payload,
+  } as any
+}
+
+test('should return 404 when STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED is false', async () => {
+  process.env.STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED = 'false'
+  const req = handlerReq('product=p1', {
+    findByID: async () => null,
+    find: async () => ({ docs: [] }),
+  })
+  const res = await storefrontVariantAvailabilityEndpoint.handler(req)
+  assert.equal(res.status, 404)
+})
+
+test('should return 400 when product query parameter is missing', async () => {
+  const req = handlerReq('', {
+    findByID: async () => null,
+    find: async () => ({ docs: [] }),
+  })
+  const res = await storefrontVariantAvailabilityEndpoint.handler(req)
+  assert.equal(res.status, 400)
+  const j = (await res.json()) as { error?: string }
+  assert.match(String(j.error), /product query/i)
+})
+
+test('should return 404 when product is not published', async () => {
+  const req = handlerReq('product=p-draft', {
+    findByID: async ({ id }: Record<string, unknown>) =>
+      id === 'p-draft' ? { id: 'p-draft', status: 'draft', tenant: null } : null,
+    find: async () => ({ docs: [] }),
+  })
+  const res = await storefrontVariantAvailabilityEndpoint.handler(req)
+  assert.equal(res.status, 404)
+})
+
+test('should return inventoryEnabled false and purchasable lines when INVENTORY_ENABLED is false', async () => {
+  process.env.INVENTORY_ENABLED = 'false'
+  const req = handlerReq('product=p1&store=loc-1', {
+    findByID: async () => ({
+      id: 'p1',
+      status: 'published',
+      tenant: null,
+    }),
+    find: async (args: Record<string, unknown>) => {
+      if (args.collection === 'product-variants') {
+        return {
+          docs: [
+            { id: 'v1', isActive: true },
+            { id: 'v2', isActive: true },
+          ],
+        }
+      }
+      return { docs: [] }
+    },
+  })
+  const res = await storefrontVariantAvailabilityEndpoint.handler(req)
+  assert.equal(res.status, 200)
+  const j = (await res.json()) as {
+    inventoryEnabled: boolean
+    productId: string
+    storeLocationId: string | null
+    lines: Array<{ variantId: string; purchasable: boolean }>
+  }
+  assert.equal(j.inventoryEnabled, false)
+  assert.equal(j.productId, 'p1')
+  assert.equal(j.storeLocationId, 'loc-1')
+  assert.equal(j.lines.length, 2)
+  assert.ok(j.lines.every((l) => l.purchasable === true))
+})
+
+test('should return inventoryEnabled true and purchasable true when stock suffices for variant', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
+  const req = handlerReq('product=p1', {
+    findByID: async () => ({
+      id: 'p1',
+      status: 'published',
+      tenant: null,
+    }),
+    find: async (args: Record<string, unknown>) => {
+      if (args.collection === 'product-variants') {
+        return { docs: [{ id: 'v1', isActive: true }] }
+      }
+      if (args.collection === 'stock-levels') {
+        return {
+          docs: [
+            {
+              id: 'sl-1',
+              product: 'p1',
+              variant: 'v1',
+              quantity: 10,
+              reservedQuantity: 0,
+              location: { id: 'warehouse-a', tenant: null },
+            },
+          ],
+        }
+      }
+      return { docs: [] }
+    },
+  })
+  const res = await storefrontVariantAvailabilityEndpoint.handler(req)
+  assert.equal(res.status, 200)
+  const j = (await res.json()) as {
+    inventoryEnabled: boolean
+    lines: Array<{ variantId: string; purchasable: boolean }>
+  }
+  assert.equal(j.inventoryEnabled, true)
+  assert.equal(j.lines.length, 1)
+  assert.equal(j.lines[0].variantId, 'v1')
+  assert.equal(j.lines[0].purchasable, true)
+})
+
+test('should return inventoryEnabled true and purchasable false when no stock for variant', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
+  const req = handlerReq('product=p1', {
+    findByID: async () => ({
+      id: 'p1',
+      status: 'published',
+      tenant: null,
+    }),
+    find: async (args: Record<string, unknown>) => {
+      if (args.collection === 'product-variants') {
+        return { docs: [{ id: 'v1', isActive: true }] }
+      }
+      if (args.collection === 'stock-levels') {
+        return { docs: [] }
+      }
+      return { docs: [] }
+    },
+  })
+  const res = await storefrontVariantAvailabilityEndpoint.handler(req)
+  assert.equal(res.status, 200)
+  const j = (await res.json()) as {
+    inventoryEnabled: boolean
+    lines: Array<{ variantId: string; purchasable: boolean }>
+  }
+  assert.equal(j.inventoryEnabled, true)
+  assert.equal(j.lines[0].purchasable, false)
+})
+
+test('should probe simple product stock when no active variants', async () => {
+  process.env.INVENTORY_ENABLED = 'true'
+  const req = handlerReq('product=p1', {
+    findByID: async () => ({
+      id: 'p1',
+      status: 'published',
+      tenant: null,
+    }),
+    find: async (args: Record<string, unknown>) => {
+      if (args.collection === 'product-variants') {
+        return { docs: [] }
+      }
+      if (args.collection === 'stock-levels') {
+        return {
+          docs: [
+            {
+              id: 'sl-1',
+              product: 'p1',
+              variant: null,
+              quantity: 5,
+              reservedQuantity: 0,
+              location: { id: 'warehouse-a', tenant: null },
+            },
+          ],
+        }
+      }
+      return { docs: [] }
+    },
+  })
+  const res = await storefrontVariantAvailabilityEndpoint.handler(req)
+  assert.equal(res.status, 200)
+  const j = (await res.json()) as {
+    inventoryEnabled: boolean
+    lines: Array<{ variantId: string | null; purchasable: boolean }>
+  }
+  assert.equal(j.inventoryEnabled, true)
+  assert.equal(j.lines.length, 1)
+  assert.equal(j.lines[0].variantId, null)
+  assert.equal(j.lines[0].purchasable, true)
+})

--- a/packages/backend/tests/unit/lib/build-reserve-quantities-by-stock-level.unit.test.ts
+++ b/packages/backend/tests/unit/lib/build-reserve-quantities-by-stock-level.unit.test.ts
@@ -5,6 +5,7 @@ import { buildReserveQuantitiesByStockLevel } from '../../../src/lib/build-reser
 
 const base = {
   productId: 'p',
+  productSlug: '',
   variantId: null as string | null,
   productName: 'P',
   variantName: '',

--- a/packages/backend/tests/unit/lib/inventory-policy.unit.test.ts
+++ b/packages/backend/tests/unit/lib/inventory-policy.unit.test.ts
@@ -1,0 +1,62 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import {
+  isInventoryEnabled,
+  shouldValidateCartWarehouseAllocation,
+  isStorefrontVariantAvailabilityEndpointEnabled,
+} from '../../../src/lib/inventory-policy.ts'
+
+let backups: Record<string, string | undefined> = {}
+beforeEach(() => {
+  backups = {
+    INVENTORY_ENABLED: process.env.INVENTORY_ENABLED,
+    INVENTORY_VALIDATE_CART_LINES: process.env.INVENTORY_VALIDATE_CART_LINES,
+    STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED:
+      process.env.STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED,
+  }
+})
+afterEach(() => {
+  for (const [k, v] of Object.entries(backups)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+})
+
+test('should treat inventory as enabled when INVENTORY_ENABLED unset', () => {
+  delete process.env.INVENTORY_ENABLED
+  assert.equal(isInventoryEnabled(), true)
+})
+
+test('should treat inventory as disabled when INVENTORY_ENABLED=false', () => {
+  process.env.INVENTORY_ENABLED = 'false'
+  assert.equal(isInventoryEnabled(), false)
+})
+
+test('should not validate cart warehouse allocation when flag unset', () => {
+  delete process.env.INVENTORY_VALIDATE_CART_LINES
+  process.env.INVENTORY_ENABLED = 'true'
+  assert.equal(shouldValidateCartWarehouseAllocation(), false)
+})
+
+test('should validate cart warehouse allocation when INVENTORY_VALIDATE_CART_LINES=true', () => {
+  process.env.INVENTORY_ENABLED = 'true'
+  process.env.INVENTORY_VALIDATE_CART_LINES = 'true'
+  assert.equal(shouldValidateCartWarehouseAllocation(), true)
+})
+
+test('should not validate cart warehouse allocation when inventory disabled', () => {
+  process.env.INVENTORY_ENABLED = 'false'
+  process.env.INVENTORY_VALIDATE_CART_LINES = 'true'
+  assert.equal(shouldValidateCartWarehouseAllocation(), false)
+})
+
+test('should disable storefront availability endpoint when env false', () => {
+  process.env.STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED = 'false'
+  assert.equal(isStorefrontVariantAvailabilityEndpointEnabled(), false)
+})
+
+test('should enable storefront availability endpoint by default when env unset', () => {
+  delete process.env.STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED
+  assert.equal(isStorefrontVariantAvailabilityEndpointEnabled(), true)
+})

--- a/packages/backend/tests/unit/orders/order-splitter.unit.test.ts
+++ b/packages/backend/tests/unit/orders/order-splitter.unit.test.ts
@@ -3,9 +3,18 @@ import assert from 'node:assert/strict'
 // @ts-ignore
 import { DefaultOrderSplitter, getPlatformItems } from '../../../src/plugins/orders/strategies/order-splitter.ts'
 
-function item(overrides: Partial<{ productId: string; tenantId: string | null; totalPrice: number; quantity: number }> = {}) {
+function item(
+  overrides: Partial<{
+    productId: string
+    productSlug: string
+    tenantId: string | null
+    totalPrice: number
+    quantity: number
+  }> = {},
+) {
   return {
     productId: overrides.productId ?? 'p1',
+    productSlug: overrides.productSlug ?? '',
     variantId: null,
     productName: 'Product',
     variantName: '',


### PR DESCRIPTION
## Summary

Aligned multi-deploy inventory behaviour across **backend**, **single-vendor storefront**, and **multivendor storefront**:

- Optional **cart warehouse validation** (`INVENTORY_VALIDATE_CART_LINES`) using the same allocation rules as checkout.
- Public **`GET /api/storefront/variant-availability`** PDP probe (toggle via env).
- Storefront **disable Add to cart** when probe reports non-purchasable SKUs; **fail-open** when backend inventory is off, probe returns `inventoryEnabled: false`, or the route returns **404** (client maps 404 → no probe).
- **Cart API errors** surfaced under Add to cart (`role="alert"`).
- Related catalog UX: Quick View, variant `?variant=` sync, order history → PDP links, ghost cart line collapse, etc.

## Repos / commits

| Repo | Branch (current) | Commit |
|------|------------------|--------|
| **BS-Commerce** | `feature/revamp-multi-warehouse-single-vendor` | `a3331d0da` |
| **storefront** | `feature/misc-improvement` | `3f56282` |
| **multivendor-storefront** | `feature/misc-improvement` | `c685d7e` |

> **Docs:** `docs/frontend/API-CONTRACT.md` and `docs/PHASE-12-MULTI-WAREHOUSE-INVENTORY.md` live under the **platform workspace** (no git root there from this environment). Commit them in whatever repo/process tracks platform docs, or paste the same contract text into backend/storefront PRs.

## Backend (`BS-Commerce`)

**Target branch:** `revamp/multivendor` (per project rules).

### Changes
- `inventory-policy.ts`: `isInventoryEnabled`, `shouldValidateCartWarehouseAllocation`, `isStorefrontVariantAvailabilityEndpointEnabled`.
- `GET /api/storefront/variant-availability` + `payload.config` registration.
- `carts` `beforeChange`: optional per-line `allocateStockLevelForLine` when flag set; legacy single-store stock path only when warehouse cart validation is off.
- Order/items/checkout/splitter updates + migration `20260507_120000_order_items_product_slug`.
- `.env.example`: `INVENTORY_VALIDATE_CART_LINES`, `STOREFRONT_VARIANT_AVAILABILITY_ENDPOINT_ENABLED`.

### Tests
- `yarn workspace @bs-commerce/backend test:unit` — **pass** (1168 tests).

### OWASP API Top 10 (touch surfaces)
- **A01 Broken Access Control:** Cart still binds user/guest; allocation uses server-side product/variant/store context (no client-trusted stock).
- **A04 Insecure Design:** Explicit env matrix for catalog-only vs strict inventory; probe optional/disabled via 404 semantics + client mapping.
- **A05 Security Misconfiguration:** New flags documented in `.env.example`; endpoint can be disabled.
- **A09 Logging / Monitoring:** Availability handler logs server errors on 500 path.

---

## Storefront (`storefront` + `multivendor-storefront`)

**Target branch:** `dev` (per project rules), unless your team uses another integration branch.

### Changes
- `getVariantAvailability` + **404 → synthetic `inventoryEnabled: false`**.
- `useWarehouseVariantAvailability` (loading / error / unavailable gates).
- `WarehouseAwareAddToCartButton`, `AddToCartButton` error display, `getApiErrorMessage` array error parsing.
- `NEXT_PUBLIC_WAREHOUSE_AVAILABILITY_UI` **default on**, explicit false-like values opt out.
- i18n: availability / Quick View strings; `.env.example` comments.

### Tests
- `yarn test:run` — **pass** (SV: 92 tests, MV: 95 tests).

---

## Checklist

- [ ] Run DB migration on environments that need `order_items.product_slug`.
- [ ] Set envs per deploy mode (see Phase 12 “Deployment modes” table once docs are merged).
- [ ] Coordinate three PRs or merge order: **backend first** (API + flags), then storefronts.