### PR TITLE
feat(checkout): enforce address-store alignment with configurable policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See `packages/backend/.env.example` for the full list.
 | `MULTIVENDOR_ENABLED` | `true` = marketplace, `false` = single-vendor |
 | `GUEST_CHECKOUT_ENABLED` | Enables guest cart + guest checkout flow |
 | `SKU_AUTOFILL_POLICY` | Product SKU generation policy: `always`, `on-publish` (default), `never` |
+| `ADDRESS_STORE_VALIDATION_MODE` | Checkout address/store alignment policy: `off`, `warn` (default), `enforce` |
 | `CHECKOUT_RATE_LIMIT_POINTS` | Max checkout requests per rate-limit window |
 | `CHECKOUT_RATE_LIMIT_DURATION_SECONDS` | Checkout rate-limit window in seconds |
 | `GUEST_LOOKUP_RATE_LIMIT_POINTS` | Max guest order-lookup requests per window |

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -183,6 +183,11 @@ LOW_STOCK_THRESHOLD=10
 # ═══════════════════════════════════════════════════
 # When false, geo collections and /api/storefront/geography are disabled (default).
 GEOGRAPHY_ENABLED=false
+# Checkout delivery address vs selected store policy:
+# - off: skip store/address alignment checks
+# - warn: allow checkout, return warning when mismatch is detected (default)
+# - enforce: block checkout on mismatch/missing mapping
+ADDRESS_STORE_VALIDATION_MODE=warn
 
 # ═══════════════════════════════════════════════════
 # REVIEWS

--- a/packages/backend/migrations/20260515_120000_addresses_geo_affinity.ts
+++ b/packages/backend/migrations/20260515_120000_addresses_geo_affinity.ts
@@ -1,0 +1,36 @@
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "addresses"
+      ADD COLUMN IF NOT EXISTS "geo_country_id" varchar,
+      ADD COLUMN IF NOT EXISTS "geo_subdivision_id" varchar,
+      ADD COLUMN IF NOT EXISTS "geo_locality_id" varchar,
+      ADD COLUMN IF NOT EXISTS "preferred_store_id" varchar;
+
+    CREATE INDEX IF NOT EXISTS "addresses_geo_country_idx"
+      ON "addresses" USING btree ("geo_country_id");
+    CREATE INDEX IF NOT EXISTS "addresses_geo_subdivision_idx"
+      ON "addresses" USING btree ("geo_subdivision_id");
+    CREATE INDEX IF NOT EXISTS "addresses_geo_locality_idx"
+      ON "addresses" USING btree ("geo_locality_id");
+    CREATE INDEX IF NOT EXISTS "addresses_preferred_store_idx"
+      ON "addresses" USING btree ("preferred_store_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "addresses_geo_country_idx";
+    DROP INDEX IF EXISTS "addresses_geo_subdivision_idx";
+    DROP INDEX IF EXISTS "addresses_geo_locality_idx";
+    DROP INDEX IF EXISTS "addresses_preferred_store_idx";
+
+    ALTER TABLE "addresses"
+      DROP COLUMN IF EXISTS "geo_country_id",
+      DROP COLUMN IF EXISTS "geo_subdivision_id",
+      DROP COLUMN IF EXISTS "geo_locality_id",
+      DROP COLUMN IF EXISTS "preferred_store_id";
+  `)
+}

--- a/packages/backend/migrations/index.ts
+++ b/packages/backend/migrations/index.ts
@@ -4,6 +4,7 @@ import * as migration_20260430_120000_add_carts_customer_note from './20260430_1
 import * as migration_20260507_120000_order_items_product_slug from './20260507_120000_order_items_product_slug';
 import * as migration_20260513_142155_add_bundle_product_type from './20260513_142155_add_bundle_product_type';
 import * as migration_20260514_171500_products_sku_optional_unique from './20260514_171500_products_sku_optional_unique';
+import * as migration_20260515_120000_addresses_geo_affinity from './20260515_120000_addresses_geo_affinity';
 
 export const migrations = [
   {
@@ -35,5 +36,10 @@ export const migrations = [
     up: migration_20260514_171500_products_sku_optional_unique.up,
     down: migration_20260514_171500_products_sku_optional_unique.down,
     name: '20260514_171500_products_sku_optional_unique',
+  },
+  {
+    up: migration_20260515_120000_addresses_geo_affinity.up,
+    down: migration_20260515_120000_addresses_geo_affinity.down,
+    name: '20260515_120000_addresses_geo_affinity',
   },
 ];

--- a/packages/backend/src/endpoints/checkout-process.ts
+++ b/packages/backend/src/endpoints/checkout-process.ts
@@ -51,6 +51,8 @@ export async function checkoutProcessHandler(req: any, deps?: CheckoutProcessDep
     cartId,
     shippingAddress,
     billingAddress,
+    storeId,
+    serviceArea,
     guestEmail,
     guestPhone,
     simulatePayment = false,
@@ -153,6 +155,17 @@ export async function checkoutProcessHandler(req: any, deps?: CheckoutProcessDep
         cartId,
         shippingAddress,
         billingAddress,
+        storeId: typeof storeId === 'string' && storeId.trim() ? storeId.trim() : undefined,
+        serviceArea: serviceArea && typeof serviceArea === 'object'
+          ? {
+              countryId:
+                typeof serviceArea.countryId === 'string' ? serviceArea.countryId : undefined,
+              subdivisionId:
+                typeof serviceArea.subdivisionId === 'string' ? serviceArea.subdivisionId : undefined,
+              localityId:
+                typeof serviceArea.localityId === 'string' ? serviceArea.localityId : undefined,
+            }
+          : undefined,
         guestEmail,
         guestPhone,
         simulatePayment: safeSimulatePayment,
@@ -165,7 +178,10 @@ export async function checkoutProcessHandler(req: any, deps?: CheckoutProcessDep
     )
     if (result.error) {
       const status = result.statusCode ?? 400
-      return Response.json({ error: result.error }, { status })
+      return Response.json(
+        { error: result.error, errorCode: result.errorCode },
+        { status },
+      )
     }
     return Response.json(result, { status: 201 })
   } catch (err) {

--- a/packages/backend/src/lib/address-store-validation.ts
+++ b/packages/backend/src/lib/address-store-validation.ts
@@ -1,0 +1,228 @@
+import type { Payload } from 'payload'
+
+export type AddressStoreValidationMode = 'off' | 'warn' | 'enforce'
+export type AddressStoreValidationCode =
+  | 'ADDRESS_STORE_NOT_FOUND'
+  | 'ADDRESS_STORE_COUNTRY_MISMATCH'
+  | 'ADDRESS_STORE_AREA_MISSING'
+  | 'ADDRESS_STORE_SUBDIVISION_UNSERVED'
+  | 'ADDRESS_STORE_LOCALITY_UNSERVED'
+  | 'ADDRESS_STORE_LOCALITY_REQUIRED'
+  | 'ADDRESS_STORE_GEOGRAPHY_REQUIRED'
+
+export type CheckoutServiceAreaInput = {
+  countryId?: string | null
+  subdivisionId?: string | null
+  localityId?: string | null
+}
+
+export type CheckoutAddressInput = {
+  country: string
+}
+
+export type AddressStoreValidationResult = {
+  warning?: string
+  error?: string
+  warningCode?: AddressStoreValidationCode
+  errorCode?: AddressStoreValidationCode
+  resolvedStoreId?: string
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeUpper(value: unknown): string {
+  return normalizeText(value).toUpperCase()
+}
+
+function normalizeId(value: unknown): string | null {
+  const v = normalizeText(value)
+  return v ? v : null
+}
+
+function relationId(value: unknown): string | null {
+  if (value == null) return null
+  if (typeof value === 'string' || typeof value === 'number') {
+    const v = String(value).trim()
+    return v ? v : null
+  }
+  if (typeof value === 'object' && 'id' in value) {
+    const id = (value as { id?: unknown }).id
+    if (id == null) return null
+    const v = String(id).trim()
+    return v ? v : null
+  }
+  return null
+}
+
+export function getAddressStoreValidationMode(): AddressStoreValidationMode {
+  const raw = (process.env.ADDRESS_STORE_VALIDATION_MODE || '').trim().toLowerCase()
+  if (raw === 'off' || raw === 'warn' || raw === 'enforce') return raw
+  return 'warn'
+}
+
+function buildViolationMessage(
+  code: AddressStoreValidationCode,
+  base: string,
+  mode: AddressStoreValidationMode,
+  storeId: string,
+): AddressStoreValidationResult {
+  if (mode === 'enforce') return { error: base, errorCode: code, resolvedStoreId: storeId }
+  return { warning: base, warningCode: code, resolvedStoreId: storeId }
+}
+
+async function validateCountryAlignment(
+  payload: Payload,
+  storeId: string,
+  shippingAddress: CheckoutAddressInput,
+  mode: AddressStoreValidationMode,
+): Promise<AddressStoreValidationResult | null> {
+  let store: unknown = null
+  try {
+    store = await payload.findByID({
+      collection: 'stock-locations',
+      id: storeId,
+      depth: 0,
+      overrideAccess: true,
+    })
+  } catch {
+    return buildViolationMessage(
+      'ADDRESS_STORE_NOT_FOUND',
+      'Selected store is not available. Please choose a valid store and retry checkout.',
+      mode,
+      storeId,
+    )
+  }
+  if (!store) {
+    return buildViolationMessage(
+      'ADDRESS_STORE_NOT_FOUND',
+      'Selected store is not available. Please choose a valid store and retry checkout.',
+      mode,
+      storeId,
+    )
+  }
+  const storeCountry = normalizeUpper((store as { address?: { country?: unknown } })?.address?.country)
+  const addressCountry = normalizeUpper(shippingAddress.country)
+  if (storeCountry && addressCountry && storeCountry !== addressCountry) {
+    return buildViolationMessage(
+      'ADDRESS_STORE_COUNTRY_MISMATCH',
+      'Shipping address country does not match the selected store service country.',
+      mode,
+      storeId,
+    )
+  }
+  return null
+}
+
+function isGeographyEnabled(): boolean {
+  return process.env.GEOGRAPHY_ENABLED === 'true'
+}
+
+async function validateGeographyCoverage(
+  payload: Payload,
+  storeId: string,
+  serviceArea: CheckoutServiceAreaInput,
+  mode: AddressStoreValidationMode,
+): Promise<AddressStoreValidationResult | null> {
+  const subdivisionId = normalizeId(serviceArea.subdivisionId)
+  const localityId = normalizeId(serviceArea.localityId)
+  if (!subdivisionId) {
+    return buildViolationMessage(
+      'ADDRESS_STORE_AREA_MISSING',
+      'Delivery area mapping is missing. Please select your delivery area again before checkout.',
+      mode,
+      storeId,
+    )
+  }
+
+  const rows = await payload.find({
+    collection: 'stock-location-service-areas',
+    where: {
+      and: [
+        { stockLocation: { equals: storeId } },
+        { subdivision: { equals: subdivisionId } },
+      ],
+    },
+    depth: 0,
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  if (rows.docs.length === 0) {
+    return buildViolationMessage(
+      'ADDRESS_STORE_SUBDIVISION_UNSERVED',
+      'Selected store does not serve the address region.',
+      mode,
+      storeId,
+    )
+  }
+
+  const localityRows = rows.docs.map((row) => relationId((row as { locality?: unknown }).locality))
+  const hasSubdivisionWideCoverage = localityRows.some((id) => id == null)
+
+  if (localityId) {
+    if (hasSubdivisionWideCoverage || localityRows.includes(localityId)) {
+      return null
+    }
+    return buildViolationMessage(
+      'ADDRESS_STORE_LOCALITY_UNSERVED',
+      'Selected store does not serve the selected local area.',
+      mode,
+      storeId,
+    )
+  }
+
+  if (hasSubdivisionWideCoverage) {
+    return null
+  }
+
+  return buildViolationMessage(
+    'ADDRESS_STORE_LOCALITY_REQUIRED',
+    'Selected store requires a more specific local delivery area for this address.',
+    mode,
+    storeId,
+  )
+}
+
+export async function validateAddressStoreAlignment(input: {
+  payload: Payload
+  shippingAddress: CheckoutAddressInput
+  storeLocationId: string | null
+  serviceArea?: CheckoutServiceAreaInput
+}): Promise<AddressStoreValidationResult> {
+  const mode = getAddressStoreValidationMode()
+  if (mode === 'off') return {}
+
+  const storeId = normalizeId(input.storeLocationId)
+  if (!storeId) return {}
+
+  const countryViolation = await validateCountryAlignment(
+    input.payload,
+    storeId,
+    input.shippingAddress,
+    mode,
+  )
+  if (countryViolation) return countryViolation
+
+  if (!isGeographyEnabled()) {
+    if (mode === 'enforce') {
+      return buildViolationMessage(
+        'ADDRESS_STORE_GEOGRAPHY_REQUIRED',
+        'Strict address-store validation requires geography data. Enable GEOGRAPHY_ENABLED or switch ADDRESS_STORE_VALIDATION_MODE to warn/off.',
+        mode,
+        storeId,
+      )
+    }
+    return { resolvedStoreId: storeId }
+  }
+
+  return (
+    (await validateGeographyCoverage(
+      input.payload,
+      storeId,
+      input.serviceArea ?? {},
+      mode,
+    )) ?? { resolvedStoreId: storeId }
+  )
+}

--- a/packages/backend/src/lib/custom-endpoints-openapi.ts
+++ b/packages/backend/src/lib/custom-endpoints-openapi.ts
@@ -98,11 +98,11 @@ export const customEndpointsOpenApi = {
       post: {
         summary: 'Process checkout payload into an order',
         description:
-          'Guest identifiers follow AUTH_REQUIRED_IDENTIFIER (guestEmail / guestPhone). cashOnDelivery with shippingMethodIds skips hosted payment when every method has collect-on-delivery enabled; order keeps checkoutPaymentChannel=cash_on_delivery and paymentStatus unpaid.',
+          'Guest identifiers follow AUTH_REQUIRED_IDENTIFIER (guestEmail / guestPhone). cashOnDelivery with shippingMethodIds skips hosted payment when every method has collect-on-delivery enabled; order keeps checkoutPaymentChannel=cash_on_delivery and paymentStatus unpaid. Optional `storeId` + `serviceArea` enable address-vs-store alignment checks controlled by ADDRESS_STORE_VALIDATION_MODE=off|warn|enforce.',
         responses: {
           201: {
             description:
-              'Order created; JSON includes order.checkoutPaymentChannel (online|cash_on_delivery), paymentStatus snapshot, optional transaction id, optional paymentRedirectUrl for hosted gateway.',
+              'Order created; JSON includes order.checkoutPaymentChannel (online|cash_on_delivery), paymentStatus snapshot, optional transaction id, optional paymentRedirectUrl for hosted gateway, and optional warnings/warningCodes/resolvedStoreId for address-store warn mode.',
           },
           400: { description: 'Invalid payload.' },
           401: { description: 'Unauthorized when required.' },

--- a/packages/backend/src/lib/process-checkout.ts
+++ b/packages/backend/src/lib/process-checkout.ts
@@ -32,6 +32,10 @@ import {
   normalizeCheckoutPhoneToE164,
   normalizeOptionalCheckoutPhone,
 } from './validation/phone-format'
+import {
+  validateAddressStoreAlignment,
+  type CheckoutServiceAreaInput,
+} from './address-store-validation'
 
 function sanitizeOrderNotesFromCart(raw: unknown): string {
   if (typeof raw !== 'string') return ''
@@ -76,6 +80,8 @@ export interface ProcessCheckoutInput {
   idempotencyKey?: string
   /** Explicit store override; falls back to cart.store if not provided. */
   storeId?: string
+  /** Optional geography ids from storefront service-area selection. */
+  serviceArea?: CheckoutServiceAreaInput
   shippingMethodIds?: string[]
   /**
    * When true with validated COD-only shipping methods, skips hosted/simulated payment;
@@ -112,7 +118,12 @@ export interface ProcessCheckoutResult {
   transaction?: { id: string }
   /** Present when the shopper must complete payment on the gateway (SSL Commerz hosted page). */
   paymentRedirectUrl?: string
+  /** Non-blocking validation notices; currently used for warn-mode address/store mismatch checks. */
+  warnings?: string[]
+  warningCodes?: string[]
+  resolvedStoreId?: string
   error?: string
+  errorCode?: string
   statusCode?: number
 }
 
@@ -292,6 +303,28 @@ export async function processCheckout(
   const storeLocationId = input.storeId
     || (cartStore ? (typeof cartStore === 'object' ? cartStore?.id : cartStore) : null)
     || null
+
+  const addressStoreValidation = await validateAddressStoreAlignment({
+    payload,
+    shippingAddress: persistShippingAddress,
+    storeLocationId,
+    serviceArea: input.serviceArea,
+  })
+  if (addressStoreValidation.error) {
+    return {
+      order: { id: '', orderNumber: '' },
+      error: addressStoreValidation.error,
+      errorCode: addressStoreValidation.errorCode,
+      statusCode: 400,
+    }
+  }
+  if (addressStoreValidation.warning) {
+    console.warn('[checkout/address-store-validation]', {
+      mode: process.env.ADDRESS_STORE_VALIDATION_MODE || 'warn',
+      code: addressStoreValidation.warningCode ?? 'UNKNOWN_WARNING',
+      storeId: addressStoreValidation.resolvedStoreId ?? storeLocationId,
+    })
+  }
 
   const items = cart.items as Array<{
     product: { id: string } | string
@@ -935,5 +968,8 @@ export async function processCheckout(
     },
     transaction: paymentTransactionId ? { id: paymentTransactionId } : undefined,
     paymentRedirectUrl,
+    warnings: addressStoreValidation.warning ? [addressStoreValidation.warning] : undefined,
+    warningCodes: addressStoreValidation.warningCode ? [addressStoreValidation.warningCode] : undefined,
+    resolvedStoreId: addressStoreValidation.resolvedStoreId ?? undefined,
   }
 }

--- a/packages/backend/src/lib/validation/address-format.ts
+++ b/packages/backend/src/lib/validation/address-format.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared address validation regexes for backend collection hooks and endpoint guards.
+ */
+export const ADDRESS_LABEL_RE = /^[\p{L}\p{M}0-9][\p{L}\p{M}0-9\s.'()/#,&-]{1,39}$/u
+export const ADDRESS_PERSON_NAME_RE = /^[\p{L}\p{M}][\p{L}\p{M}\s.'-]{0,62}$/u
+export const ADDRESS_STREET_RE = /^[\p{L}\p{M}0-9#][\p{L}\p{M}0-9\s.,'()/#-]{2,119}$/u
+export const ADDRESS_PLACE_RE = /^[\p{L}\p{M}0-9][\p{L}\p{M}0-9\s.'()/#,-]{1,79}$/u
+export const ADDRESS_POSTAL_RE = /^(?=.{3,12}$)[A-Za-z0-9][A-Za-z0-9 -]*$/
+export const ADDRESS_ISO_COUNTRY_RE = /^[A-Za-z]{2}$/
+export const ADDRESS_PHONE_RE = /^[0-9+()\-\s]{5,20}$/

--- a/packages/backend/src/plugins/ecommerce/collections/addresses.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/addresses.ts
@@ -1,5 +1,31 @@
 import type { CollectionConfig } from 'payload'
 import { isOwnerOrAdmin } from '../../../access/is-owner-or-admin'
+import {
+  ADDRESS_ISO_COUNTRY_RE,
+  ADDRESS_LABEL_RE,
+  ADDRESS_PERSON_NAME_RE,
+  ADDRESS_PHONE_RE,
+  ADDRESS_PLACE_RE,
+  ADDRESS_POSTAL_RE,
+  ADDRESS_STREET_RE,
+} from '../../../lib/validation/address-format'
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isValidOptionalPhone(value: string): boolean {
+  if (!value) return true
+  if (!ADDRESS_PHONE_RE.test(value)) return false
+  const digits = value.replace(/\D/g, '').length
+  return digits >= 5 && digits <= 15
+}
+
+function assertMatches(value: string, pattern: RegExp, message: string): void {
+  if (!pattern.test(value)) {
+    throw new Error(message)
+  }
+}
 
 export const Addresses: CollectionConfig = {
   slug: 'addresses',
@@ -15,6 +41,59 @@ export const Addresses: CollectionConfig = {
     delete: isOwnerOrAdmin(),
   },
   hooks: {
+    beforeValidate: [
+      ({ data, originalDoc }) => {
+        if (!data) return data
+
+        const label = normalizeText(data.label ?? originalDoc?.label)
+        const firstName = normalizeText(data.firstName ?? originalDoc?.firstName)
+        const lastName = normalizeText(data.lastName ?? originalDoc?.lastName)
+        const street1 = normalizeText(data.street1 ?? originalDoc?.street1)
+        const street2 = normalizeText(data.street2 ?? originalDoc?.street2)
+        const city = normalizeText(data.city ?? originalDoc?.city)
+        const state = normalizeText(data.state ?? originalDoc?.state)
+        const postalCode = normalizeText(data.postalCode ?? originalDoc?.postalCode)
+        const country = normalizeText(data.country ?? originalDoc?.country).toUpperCase()
+        const phone = normalizeText(data.phone ?? originalDoc?.phone)
+
+        if (!label) throw new Error('Address label is required.')
+        if (!firstName) throw new Error('First name is required.')
+        if (!lastName) throw new Error('Last name is required.')
+        if (!street1) throw new Error('Street address is required.')
+        if (!city) throw new Error('City/local area is required.')
+        if (!country) throw new Error('Country is required.')
+
+        assertMatches(label, ADDRESS_LABEL_RE, 'Address label contains invalid characters.')
+        assertMatches(firstName, ADDRESS_PERSON_NAME_RE, 'First name contains invalid characters.')
+        assertMatches(lastName, ADDRESS_PERSON_NAME_RE, 'Last name contains invalid characters.')
+        assertMatches(street1, ADDRESS_STREET_RE, 'Street address looks invalid.')
+        assertMatches(city, ADDRESS_PLACE_RE, 'City/local area looks invalid.')
+        if (state) assertMatches(state, ADDRESS_PLACE_RE, 'Region looks invalid.')
+        if (street2) assertMatches(street2, ADDRESS_STREET_RE, 'Street line 2 looks invalid.')
+        if (postalCode && !ADDRESS_POSTAL_RE.test(postalCode)) {
+          throw new Error('Postal code looks invalid.')
+        }
+        if (!ADDRESS_ISO_COUNTRY_RE.test(country)) {
+          throw new Error('Country must be a valid 2-letter ISO code.')
+        }
+        if (!isValidOptionalPhone(phone)) {
+          throw new Error('Phone number looks invalid.')
+        }
+
+        if (data.label !== undefined) data.label = label
+        if (data.firstName !== undefined) data.firstName = firstName
+        if (data.lastName !== undefined) data.lastName = lastName
+        if (data.street1 !== undefined) data.street1 = street1
+        if (data.street2 !== undefined) data.street2 = street2 || null
+        if (data.city !== undefined) data.city = city
+        if (data.state !== undefined) data.state = state || null
+        if (data.postalCode !== undefined) data.postalCode = postalCode || null
+        if (data.country !== undefined) data.country = country
+        if (data.phone !== undefined) data.phone = phone || null
+
+        return data
+      },
+    ],
     beforeChange: [
       ({ data, req }) => {
         if (req.user?.role !== 'admin' && data) {
@@ -40,6 +119,39 @@ export const Addresses: CollectionConfig = {
     { name: 'state', type: 'text' },
     { name: 'postalCode', type: 'text' },
     { name: 'country', type: 'text', required: true },
+    {
+      name: 'geoCountryId',
+      type: 'text',
+      index: true,
+      admin: {
+        description: 'Optional geography country id (for store/service-area compatibility checks).',
+      },
+    },
+    {
+      name: 'geoSubdivisionId',
+      type: 'text',
+      index: true,
+      admin: {
+        description: 'Optional geography subdivision id (for store/service-area compatibility checks).',
+      },
+    },
+    {
+      name: 'geoLocalityId',
+      type: 'text',
+      index: true,
+      admin: {
+        description:
+          'Optional geography locality id. Leave empty when the address is subdivision-level only.',
+      },
+    },
+    {
+      name: 'preferredStoreId',
+      type: 'text',
+      index: true,
+      admin: {
+        description: 'Optional preferred store/outlet id used for compatibility hints in storefront.',
+      },
+    },
     { name: 'phone', type: 'text' },
     { name: 'isDefault', type: 'checkbox', defaultValue: false },
   ],

--- a/packages/backend/tests/unit/checkout/process-checkout.unit.test.ts
+++ b/packages/backend/tests/unit/checkout/process-checkout.unit.test.ts
@@ -8,6 +8,8 @@ const envKeys = [
   'MULTIVENDOR_ENABLED',
   'INVENTORY_ENABLED',
   'REQUIRE_VERIFIED_FOR_CHECKOUT',
+  'ADDRESS_STORE_VALIDATION_MODE',
+  'GEOGRAPHY_ENABLED',
   'DEFAULT_COMMISSION_RATE',
   'BS_TEST_ORDER_EMAIL_REJECT',
   'PAYMENT_PROVIDER',
@@ -445,6 +447,85 @@ test('should block unverified user when REQUIRE_VERIFIED_FOR_CHECKOUT is on', as
   const result = await processCheckout(payload, { ...baseInput }, 'u-1', req)
   assert.equal(result.statusCode, 403)
   assert.ok(result.error?.includes('verified'))
+})
+
+test('should block checkout when address/store country mismatch and validation mode is enforce', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'enforce'
+  const payload = buildPayload({
+    findByID: async (args: any) => {
+      if (args.collection === 'stock-locations') {
+        return { id: 'store-1', address: { country: 'BD' } }
+      }
+      if (args.collection === 'carts') {
+        return {
+          id: 'cart-1',
+          guestId: 'guest-abc',
+          store: { id: 'store-1' },
+          items: [{ product: { id: 'prod-1' }, quantity: 1, unitPrice: 50 }],
+        }
+      }
+      if (args.collection === 'products') return { id: 'prod-1', name: 'P', basePrice: 50, tenant: null }
+      return { id: args.id }
+    },
+  })
+
+  const result = await processCheckout(
+    payload,
+    {
+      ...baseInput,
+      shippingAddress: { ...baseInput.shippingAddress, country: 'US' },
+      billingAddress: { ...baseInput.billingAddress, country: 'US' },
+      guestEmail: 'country-mismatch@test.com',
+    },
+    undefined,
+    guestReq(),
+  )
+  assert.equal(result.statusCode, 400)
+  assert.ok(result.error?.includes('country'))
+})
+
+test('should return warning when geography mapping fails and validation mode is warn', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'warn'
+  process.env.GEOGRAPHY_ENABLED = 'true'
+
+  const payload = buildPayload({
+    findByID: async (args: any) => {
+      if (args.collection === 'stock-locations') {
+        return { id: 'store-1', address: { country: 'US' } }
+      }
+      if (args.collection === 'carts') {
+        return {
+          id: 'cart-1',
+          guestId: 'guest-abc',
+          store: { id: 'store-1' },
+          items: [{ product: { id: 'prod-1' }, quantity: 1, unitPrice: 50 }],
+        }
+      }
+      if (args.collection === 'products') return { id: 'prod-1', name: 'P', basePrice: 50, tenant: null }
+      return { id: args.id }
+    },
+    find: async (args: any) => {
+      if (args.collection === 'stock-location-service-areas') {
+        return { docs: [] }
+      }
+      if (args.collection === 'orders') return { docs: [] }
+      return { docs: [], totalDocs: 0 }
+    },
+  })
+
+  const result = await processCheckout(
+    payload,
+    {
+      ...baseInput,
+      guestEmail: 'warn@test.com',
+      storeId: 'store-1',
+      serviceArea: { subdivisionId: 'subdivision-x', localityId: 'locality-x' },
+    },
+    undefined,
+    guestReq(),
+  )
+  assert.equal(result.error, undefined)
+  assert.ok(result.warnings?.length)
 })
 
 test('should delete cart after successful checkout', async () => {

--- a/packages/backend/tests/unit/collections/addresses-hooks.unit.test.ts
+++ b/packages/backend/tests/unit/collections/addresses-hooks.unit.test.ts
@@ -3,6 +3,72 @@ import assert from 'node:assert/strict'
 // @ts-ignore
 import { Addresses } from '../../../src/plugins/ecommerce/collections/addresses.ts'
 
+test('beforeValidate should normalize and uppercase address fields', () => {
+  const hook = Addresses.hooks?.beforeValidate?.[0] as any
+  assert.ok(hook)
+  const out = hook({
+    data: {
+      label: ' home ',
+      firstName: ' John ',
+      lastName: ' Doe ',
+      street1: ' 123 Main St ',
+      city: ' Dhaka ',
+      country: ' bd ',
+      state: ' Dhaka ',
+      postalCode: ' 1207 ',
+      phone: ' +880 1712345678 ',
+    },
+    originalDoc: undefined,
+  })
+  assert.equal(out.label, 'home')
+  assert.equal(out.firstName, 'John')
+  assert.equal(out.lastName, 'Doe')
+  assert.equal(out.street1, '123 Main St')
+  assert.equal(out.city, 'Dhaka')
+  assert.equal(out.country, 'BD')
+  assert.equal(out.state, 'Dhaka')
+  assert.equal(out.postalCode, '1207')
+  assert.equal(out.phone, '+880 1712345678')
+})
+
+test('beforeValidate should reject invalid country code', () => {
+  const hook = Addresses.hooks?.beforeValidate?.[0] as any
+  assert.throws(
+    () =>
+      hook({
+        data: {
+          label: 'Home',
+          firstName: 'John',
+          lastName: 'Doe',
+          street1: '123 Main St',
+          city: 'Dhaka',
+          country: 'Bangladesh',
+        },
+        originalDoc: undefined,
+      }),
+    /2-letter ISO code/,
+  )
+})
+
+test('beforeValidate should reject clearly invalid street input', () => {
+  const hook = Addresses.hooks?.beforeValidate?.[0] as any
+  assert.throws(
+    () =>
+      hook({
+        data: {
+          label: 'Home',
+          firstName: 'John',
+          lastName: 'Doe',
+          street1: '!!!',
+          city: 'Dhaka',
+          country: 'BD',
+        },
+        originalDoc: undefined,
+      }),
+    /Street address looks invalid/,
+  )
+})
+
 test('beforeChange should force user to self for non-admin', () => {
   const hook = Addresses.hooks?.beforeChange?.[0] as any
   assert.ok(hook)

--- a/packages/backend/tests/unit/config/env-defaults.unit.test.ts
+++ b/packages/backend/tests/unit/config/env-defaults.unit.test.ts
@@ -16,6 +16,7 @@ const envKeys = [
   'VENDOR_AUTO_APPROVE',
   'CHECKOUT_RATE_LIMIT_POINTS',
   'CHECKOUT_RATE_LIMIT_DURATION_SECONDS',
+  'ADDRESS_STORE_VALIDATION_MODE',
 ]
 
 let backups: Record<string, string | undefined> = {}
@@ -84,4 +85,10 @@ test('VENDOR_AUTO_APPROVE defaults to falsy', () => {
 test('DEFAULT_COMMISSION_RATE defaults to 0', () => {
   const rate = Number(process.env.DEFAULT_COMMISSION_RATE ?? '0')
   assert.equal(rate, 0)
+})
+
+test('ADDRESS_STORE_VALIDATION_MODE defaults to "warn"', async () => {
+  // @ts-ignore
+  const { getAddressStoreValidationMode } = await import('../../../src/lib/address-store-validation.ts')
+  assert.equal(getAddressStoreValidationMode(), 'warn')
 })

--- a/packages/backend/tests/unit/endpoints/checkout-process.unit.test.ts
+++ b/packages/backend/tests/unit/endpoints/checkout-process.unit.test.ts
@@ -178,6 +178,41 @@ test('should return 201 when processCheckout succeeds', async () => {
   assert.equal(j.order && (j.order as { orderNumber: string }).orderNumber, 'ORD-99')
 })
 
+test('should pass storeId and serviceArea to processCheckout when provided', async () => {
+  let seenStoreId: string | undefined
+  let seenServiceArea:
+    | { countryId?: string | null; subdivisionId?: string | null; localityId?: string | null }
+    | undefined
+  const req = mockHandlerReq({
+    body: {
+      ...baseBody,
+      storeId: 'store-1',
+      serviceArea: {
+        countryId: 'country-1',
+        subdivisionId: 'subdivision-1',
+        localityId: 'locality-1',
+      },
+    },
+  })
+  const res = await checkoutProcessHandler(req, {
+    enforceRateLimit: async () => null,
+    processCheckout: async (_p, input) => {
+      seenStoreId = input.storeId
+      seenServiceArea = input.serviceArea
+      return {
+        order: { id: 'order-1', orderNumber: 'ORD-99' },
+      }
+    },
+  })
+  assert.equal(res.status, 201)
+  assert.equal(seenStoreId, 'store-1')
+  assert.deepEqual(seenServiceArea, {
+    countryId: 'country-1',
+    subdivisionId: 'subdivision-1',
+    localityId: 'locality-1',
+  })
+})
+
 test('should allow authenticated checkout without guestEmail when user is present', async () => {
   const req = mockHandlerReq({
     body: { cartId: 'c1', shippingAddress: validAddr, billingAddress: validAddr },
@@ -206,6 +241,22 @@ test('should return processCheckout error status when business logic fails', asy
   assert.equal(res.status, 404)
   const j = await jsonBody(res)
   assert.equal(j.error, 'Cart not found')
+})
+
+test('should return processCheckout errorCode when provided', async () => {
+  const req = mockHandlerReq({ body: baseBody })
+  const res = await checkoutProcessHandler(req, {
+    enforceRateLimit: async () => null,
+    processCheckout: async () => ({
+      order: { id: '', orderNumber: '' },
+      error: 'Area mismatch',
+      errorCode: 'ADDRESS_STORE_LOCALITY_UNSERVED',
+      statusCode: 400,
+    }),
+  })
+  assert.equal(res.status, 400)
+  const j = await jsonBody(res)
+  assert.equal(j.errorCode, 'ADDRESS_STORE_LOCALITY_UNSERVED')
 })
 
 test('should default to 400 when processCheckout error omits statusCode', async () => {

--- a/packages/backend/tests/unit/lib/address-store-validation.unit.test.ts
+++ b/packages/backend/tests/unit/lib/address-store-validation.unit.test.ts
@@ -1,0 +1,134 @@
+import test, { afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import { validateAddressStoreAlignment } from '../../../src/lib/address-store-validation.ts'
+
+const envBackup = {
+  ADDRESS_STORE_VALIDATION_MODE: process.env.ADDRESS_STORE_VALIDATION_MODE,
+  GEOGRAPHY_ENABLED: process.env.GEOGRAPHY_ENABLED,
+}
+
+afterEach(() => {
+  if (envBackup.ADDRESS_STORE_VALIDATION_MODE === undefined) {
+    delete process.env.ADDRESS_STORE_VALIDATION_MODE
+  } else {
+    process.env.ADDRESS_STORE_VALIDATION_MODE = envBackup.ADDRESS_STORE_VALIDATION_MODE
+  }
+  if (envBackup.GEOGRAPHY_ENABLED === undefined) {
+    delete process.env.GEOGRAPHY_ENABLED
+  } else {
+    process.env.GEOGRAPHY_ENABLED = envBackup.GEOGRAPHY_ENABLED
+  }
+})
+
+function payloadStub(args?: {
+  storeCountry?: string
+  serviceAreaDocs?: Array<{ locality?: string | null }>
+}) {
+  return {
+    findByID: async (input: { collection: string }) => {
+      if (input.collection === 'stock-locations') {
+        return { id: 'store-1', address: { country: args?.storeCountry ?? 'BD' } }
+      }
+      return null
+    },
+    find: async (input: { collection: string }) => {
+      if (input.collection === 'stock-location-service-areas') {
+        return { docs: args?.serviceAreaDocs ?? [] }
+      }
+      return { docs: [] }
+    },
+  } as any
+}
+
+test('should skip validation when mode is off', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'off'
+  process.env.GEOGRAPHY_ENABLED = 'true'
+  const result = await validateAddressStoreAlignment({
+    payload: payloadStub(),
+    shippingAddress: { country: 'US' },
+    storeLocationId: 'store-1',
+    serviceArea: { subdivisionId: 'sub-1' },
+  })
+  assert.deepEqual(result, {})
+})
+
+test('should return warning in warn mode for country mismatch', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'warn'
+  process.env.GEOGRAPHY_ENABLED = 'false'
+  const result = await validateAddressStoreAlignment({
+    payload: payloadStub({ storeCountry: 'BD' }),
+    shippingAddress: { country: 'US' },
+    storeLocationId: 'store-1',
+  })
+  assert.equal(result.warningCode, 'ADDRESS_STORE_COUNTRY_MISMATCH')
+  assert.ok(result.warning)
+})
+
+test('should return error in enforce mode when geography is disabled', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'enforce'
+  process.env.GEOGRAPHY_ENABLED = 'false'
+  const result = await validateAddressStoreAlignment({
+    payload: payloadStub({ storeCountry: 'BD' }),
+    shippingAddress: { country: 'BD' },
+    storeLocationId: 'store-1',
+  })
+  assert.equal(result.errorCode, 'ADDRESS_STORE_GEOGRAPHY_REQUIRED')
+  assert.ok(result.error?.includes('GEOGRAPHY_ENABLED'))
+})
+
+test('should return error in enforce mode when locality is unserved', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'enforce'
+  process.env.GEOGRAPHY_ENABLED = 'true'
+  const result = await validateAddressStoreAlignment({
+    payload: payloadStub({ serviceAreaDocs: [{ locality: 'loc-a' }] }),
+    shippingAddress: { country: 'BD' },
+    storeLocationId: 'store-1',
+    serviceArea: { subdivisionId: 'sub-1', localityId: 'loc-b' },
+  })
+  assert.equal(result.errorCode, 'ADDRESS_STORE_LOCALITY_UNSERVED')
+  assert.ok(result.error)
+})
+
+test('should pass when subdivision-wide coverage exists', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'enforce'
+  process.env.GEOGRAPHY_ENABLED = 'true'
+  const result = await validateAddressStoreAlignment({
+    payload: payloadStub({ serviceAreaDocs: [{ locality: null }] }),
+    shippingAddress: { country: 'BD' },
+    storeLocationId: 'store-1',
+    serviceArea: { subdivisionId: 'sub-1' },
+  })
+  assert.equal(result.error, undefined)
+  assert.equal(result.warning, undefined)
+})
+
+test('should preserve legacy behavior when no store is selected', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'enforce'
+  process.env.GEOGRAPHY_ENABLED = 'true'
+  const result = await validateAddressStoreAlignment({
+    payload: payloadStub(),
+    shippingAddress: { country: 'US' },
+    storeLocationId: null,
+    serviceArea: { subdivisionId: 'sub-1' },
+  })
+  assert.deepEqual(result, {})
+})
+
+test('should return controlled not-found error when selected store does not exist', async () => {
+  process.env.ADDRESS_STORE_VALIDATION_MODE = 'enforce'
+  process.env.GEOGRAPHY_ENABLED = 'true'
+  const result = await validateAddressStoreAlignment({
+    payload: {
+      findByID: async () => {
+        throw new Error('not found')
+      },
+      find: async () => ({ docs: [] }),
+    } as any,
+    shippingAddress: { country: 'BD' },
+    storeLocationId: 'missing-store',
+    serviceArea: { subdivisionId: 'sub-1' },
+  })
+  assert.equal(result.errorCode, 'ADDRESS_STORE_NOT_FOUND')
+  assert.ok(result.error?.includes('store'))
+})


### PR DESCRIPTION
## Summary
- Enforce checkout address-to-store alignment with configurable policy modes (`off | warn | enforce`) to prevent invalid delivery/store pairings.
- Extend address model with optional geography affinity fields for safer store-aware reuse in storefront checkout and account flows.
- Centralize backend address regex rules and add dedicated tests/migration/docs updates.

## Key Changes
- Added `ADDRESS_STORE_VALIDATION_MODE` support and documentation (`README.md`, `.env.example`).
- Implemented checkout alignment validator (`src/lib/address-store-validation.ts`) with controlled warning/error codes.
- Updated checkout processing and endpoint wiring to accept `storeId` + `serviceArea`, and return `errorCode` in failures.
- Added optional address affinity persistence fields and migration:
  - `geo_country_id`, `geo_subdivision_id`, `geo_locality_id`, `preferred_store_id`
  - migration registration in `migrations/index.ts`
- Moved address format regexes to shared backend validation module (`src/lib/validation/address-format.ts`) and consumed in addresses collection hook.
- Added/updated unit tests for:
  - checkout process and endpoint propagation,
  - environment default mode behavior,
  - address validation hook behavior,
  - dedicated address-store validation scenarios.

## Test Plan
- [x] `yarn typecheck`
- [x] `yarn test:unit`
- [x] `yarn test:unit:cov`
- [ ] Run migration in target environment and verify rollback path:
  - [ ] `yarn db:migrate`
  - [ ] smoke-check address CRUD + checkout with `off/warn/enforce`