### PR TITLE
feat(wishlist): add wishlist collection and schema migrations

### DIFF
--- a/packages/backend/migrations/20260601_141500_wishlist_items.ts
+++ b/packages/backend/migrations/20260601_141500_wishlist_items.ts
@@ -1,0 +1,227 @@
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  const idType = (process.env.DATABASE_ID_TYPE as 'serial' | 'uuid' | undefined) ?? 'uuid'
+
+  if (idType === 'serial') {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS "wishlist_items" (
+        "id" serial PRIMARY KEY NOT NULL,
+        "user_id" integer NOT NULL,
+        "product_id" integer NOT NULL,
+        "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+        "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+      );
+
+      DO $$
+      BEGIN
+        -- Recovery path for partially-applied previous versions of this migration.
+        IF EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'wishlist_items'
+            AND column_name = 'id'
+            AND udt_name <> 'int4'
+        ) THEN
+          IF EXISTS (
+            SELECT 1
+            FROM "wishlist_items"
+            WHERE btrim("id"::text) !~ '^[0-9]+$'
+          ) THEN
+            RAISE EXCEPTION 'wishlist_items.id contains non-integer values; cleanup required before migration';
+          END IF;
+          ALTER TABLE "wishlist_items" ALTER COLUMN "id" TYPE integer USING ("id"::integer);
+        END IF;
+
+        IF EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'wishlist_items'
+            AND column_name = 'user_id'
+            AND udt_name <> 'int4'
+        ) THEN
+          IF EXISTS (
+            SELECT 1
+            FROM "wishlist_items"
+            WHERE btrim("user_id"::text) !~ '^[0-9]+$'
+          ) THEN
+            RAISE EXCEPTION 'wishlist_items.user_id contains non-integer values; cleanup required before migration';
+          END IF;
+          ALTER TABLE "wishlist_items" ALTER COLUMN "user_id" TYPE integer USING ("user_id"::integer);
+        END IF;
+
+        IF EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'wishlist_items'
+            AND column_name = 'product_id'
+            AND udt_name <> 'int4'
+        ) THEN
+          IF EXISTS (
+            SELECT 1
+            FROM "wishlist_items"
+            WHERE btrim("product_id"::text) !~ '^[0-9]+$'
+          ) THEN
+            RAISE EXCEPTION 'wishlist_items.product_id contains non-integer values; cleanup required before migration';
+          END IF;
+          ALTER TABLE "wishlist_items" ALTER COLUMN "product_id" TYPE integer USING ("product_id"::integer);
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_class WHERE relname = 'wishlist_items_id_seq'
+        ) THEN
+          CREATE SEQUENCE "wishlist_items_id_seq";
+        END IF;
+
+        ALTER TABLE "wishlist_items" ALTER COLUMN "id" SET DEFAULT nextval('"wishlist_items_id_seq"');
+        ALTER SEQUENCE "wishlist_items_id_seq" OWNED BY "wishlist_items"."id";
+        PERFORM setval('"wishlist_items_id_seq"', COALESCE((SELECT MAX("id") FROM "wishlist_items"), 0) + 1, false);
+      END $$;
+
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'wishlist_items_user_fk'
+        ) THEN
+          ALTER TABLE "wishlist_items"
+            ADD CONSTRAINT "wishlist_items_user_fk"
+            FOREIGN KEY ("user_id") REFERENCES "users"("id")
+            ON DELETE cascade ON UPDATE no action;
+        END IF;
+      END $$;
+
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'wishlist_items_product_fk'
+        ) THEN
+          ALTER TABLE "wishlist_items"
+            ADD CONSTRAINT "wishlist_items_product_fk"
+            FOREIGN KEY ("product_id") REFERENCES "products"("id")
+            ON DELETE cascade ON UPDATE no action;
+        END IF;
+      END $$;
+
+      CREATE INDEX IF NOT EXISTS "wishlist_items_user_idx" ON "wishlist_items" USING btree ("user_id");
+      CREATE INDEX IF NOT EXISTS "wishlist_items_product_idx" ON "wishlist_items" USING btree ("product_id");
+      CREATE UNIQUE INDEX IF NOT EXISTS "wishlist_items_user_product_unique"
+        ON "wishlist_items" USING btree ("user_id", "product_id");
+    `)
+    return
+  }
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "wishlist_items" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "user_id" uuid NOT NULL,
+      "product_id" uuid NOT NULL,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+
+    DO $$
+    BEGIN
+      -- Recovery path for partially-applied previous versions of this migration.
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'wishlist_items'
+          AND column_name = 'id'
+          AND udt_name <> 'uuid'
+      ) THEN
+        IF EXISTS (
+          SELECT 1
+          FROM "wishlist_items"
+          WHERE "id" !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        ) THEN
+          RAISE EXCEPTION 'wishlist_items.id contains non-UUID values; cleanup required before migration';
+        END IF;
+        ALTER TABLE "wishlist_items" ALTER COLUMN "id" TYPE uuid USING "id"::uuid;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'wishlist_items'
+          AND column_name = 'user_id'
+          AND udt_name <> 'uuid'
+      ) THEN
+        IF EXISTS (
+          SELECT 1
+          FROM "wishlist_items"
+          WHERE "user_id" !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        ) THEN
+          RAISE EXCEPTION 'wishlist_items.user_id contains non-UUID values; cleanup required before migration';
+        END IF;
+        ALTER TABLE "wishlist_items" ALTER COLUMN "user_id" TYPE uuid USING "user_id"::uuid;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'wishlist_items'
+          AND column_name = 'product_id'
+          AND udt_name <> 'uuid'
+      ) THEN
+        IF EXISTS (
+          SELECT 1
+          FROM "wishlist_items"
+          WHERE "product_id" !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        ) THEN
+          RAISE EXCEPTION 'wishlist_items.product_id contains non-UUID values; cleanup required before migration';
+        END IF;
+        ALTER TABLE "wishlist_items" ALTER COLUMN "product_id" TYPE uuid USING "product_id"::uuid;
+      END IF;
+    END $$;
+
+    ALTER TABLE "wishlist_items"
+      ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'wishlist_items_user_fk'
+      ) THEN
+        ALTER TABLE "wishlist_items"
+          ADD CONSTRAINT "wishlist_items_user_fk"
+          FOREIGN KEY ("user_id") REFERENCES "users"("id")
+          ON DELETE cascade ON UPDATE no action;
+      END IF;
+    END $$;
+
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'wishlist_items_product_fk'
+      ) THEN
+        ALTER TABLE "wishlist_items"
+          ADD CONSTRAINT "wishlist_items_product_fk"
+          FOREIGN KEY ("product_id") REFERENCES "products"("id")
+          ON DELETE cascade ON UPDATE no action;
+      END IF;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "wishlist_items_user_idx" ON "wishlist_items" USING btree ("user_id");
+    CREATE INDEX IF NOT EXISTS "wishlist_items_product_idx" ON "wishlist_items" USING btree ("product_id");
+    CREATE UNIQUE INDEX IF NOT EXISTS "wishlist_items_user_product_unique"
+      ON "wishlist_items" USING btree ("user_id", "product_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "wishlist_items_user_product_unique";
+    DROP INDEX IF EXISTS "wishlist_items_product_idx";
+    DROP INDEX IF EXISTS "wishlist_items_user_idx";
+    ALTER TABLE IF EXISTS "wishlist_items" DROP CONSTRAINT IF EXISTS "wishlist_items_product_fk";
+    ALTER TABLE IF EXISTS "wishlist_items" DROP CONSTRAINT IF EXISTS "wishlist_items_user_fk";
+    DROP TABLE IF EXISTS "wishlist_items" CASCADE;
+  `)
+}

--- a/packages/backend/migrations/20260601_153000_add_wishlist_locked_rels.ts
+++ b/packages/backend/migrations/20260601_153000_add_wishlist_locked_rels.ts
@@ -1,0 +1,40 @@
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  const idType = (process.env.DATABASE_ID_TYPE as 'serial' | 'uuid' | undefined) ?? 'uuid'
+  const relType = idType === 'serial' ? sql`integer` : sql`uuid`
+
+  await db.execute(sql`
+    ALTER TABLE "payload_locked_documents_rels"
+      ADD COLUMN IF NOT EXISTS "wishlist_items_id" ${relType};
+
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'payload_locked_documents_rels_wishlist_items_fk'
+      ) THEN
+        ALTER TABLE "payload_locked_documents_rels"
+          ADD CONSTRAINT "payload_locked_documents_rels_wishlist_items_fk"
+          FOREIGN KEY ("wishlist_items_id")
+          REFERENCES "wishlist_items"("id")
+          ON DELETE cascade
+          ON UPDATE no action;
+      END IF;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_wishlist_items_id_idx"
+      ON "payload_locked_documents_rels" USING btree ("wishlist_items_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_wishlist_items_id_idx";
+    ALTER TABLE IF EXISTS "payload_locked_documents_rels"
+      DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_wishlist_items_fk";
+    ALTER TABLE IF EXISTS "payload_locked_documents_rels"
+      DROP COLUMN IF EXISTS "wishlist_items_id";
+  `)
+}

--- a/packages/backend/migrations/index.ts
+++ b/packages/backend/migrations/index.ts
@@ -5,6 +5,8 @@ import * as migration_20260507_120000_order_items_product_slug from './20260507_
 import * as migration_20260513_142155_add_bundle_product_type from './20260513_142155_add_bundle_product_type';
 import * as migration_20260514_171500_products_sku_optional_unique from './20260514_171500_products_sku_optional_unique';
 import * as migration_20260515_120000_addresses_geo_affinity from './20260515_120000_addresses_geo_affinity';
+import * as migration_20260601_141500_wishlist_items from './20260601_141500_wishlist_items';
+import * as migration_20260601_153000_add_wishlist_locked_rels from './20260601_153000_add_wishlist_locked_rels';
 
 export const migrations = [
   {
@@ -41,5 +43,15 @@ export const migrations = [
     up: migration_20260515_120000_addresses_geo_affinity.up,
     down: migration_20260515_120000_addresses_geo_affinity.down,
     name: '20260515_120000_addresses_geo_affinity',
+  },
+  {
+    up: migration_20260601_141500_wishlist_items.up,
+    down: migration_20260601_141500_wishlist_items.down,
+    name: '20260601_141500_wishlist_items',
+  },
+  {
+    up: migration_20260601_153000_add_wishlist_locked_rels.up,
+    down: migration_20260601_153000_add_wishlist_locked_rels.down,
+    name: '20260601_153000_add_wishlist_locked_rels',
   },
 ];

--- a/packages/backend/src/plugins/ecommerce/collections/wishlist-items.ts
+++ b/packages/backend/src/plugins/ecommerce/collections/wishlist-items.ts
@@ -1,0 +1,82 @@
+import { APIError, type CollectionConfig, type Where } from 'payload'
+import { isOwnerOrAdmin } from '../../../access/is-owner-or-admin'
+
+function relationId(value: unknown): string | null {
+  if (value == null) return null
+  if (typeof value === 'string' || typeof value === 'number') {
+    const t = String(value).trim()
+    return t.length > 0 ? t : null
+  }
+  if (typeof value === 'object' && 'id' in value) {
+    const id = (value as { id?: unknown }).id
+    if (id == null) return null
+    const t = String(id).trim()
+    return t.length > 0 ? t : null
+  }
+  return null
+}
+
+export const WishlistItems: CollectionConfig = {
+  slug: 'wishlist-items',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['user', 'product', 'createdAt'],
+    group: 'Ecommerce',
+  },
+  access: {
+    create: ({ req }) => Boolean(req.user),
+    read: isOwnerOrAdmin(),
+    update: isOwnerOrAdmin(),
+    delete: isOwnerOrAdmin(),
+  },
+  hooks: {
+    beforeChange: [
+      async ({ data, originalDoc, operation, req }) => {
+        if (!data) return data
+        if (req.user?.role !== 'admin' && req.user?.id != null) {
+          data.user = req.user.id
+        }
+
+        const userId = relationId(data.user ?? originalDoc?.user)
+        const productId = relationId(data.product ?? originalDoc?.product)
+        if (!userId || !productId) return data
+
+        const selfId = operation === 'update' ? relationId(originalDoc?.id) : null
+        const where: Where = {
+          and: [
+            { user: { equals: userId } },
+            { product: { equals: productId } },
+            ...(selfId ? [{ id: { not_equals: selfId } }] : []),
+          ],
+        }
+
+        const existing = await req.payload.find({
+          collection: 'wishlist-items',
+          where,
+          depth: 0,
+          limit: 1,
+          overrideAccess: true,
+        })
+        if ((existing.docs?.length || 0) > 0) {
+          throw new APIError('This product is already in your wishlist.', 400)
+        }
+        return data
+      },
+    ],
+  },
+  fields: [
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+    },
+    {
+      name: 'product',
+      type: 'relationship',
+      relationTo: 'products',
+      required: true,
+    },
+  ],
+  timestamps: true,
+}

--- a/packages/backend/src/plugins/ecommerce/index.ts
+++ b/packages/backend/src/plugins/ecommerce/index.ts
@@ -3,6 +3,7 @@ import { createProductsConfig } from './collections/products'
 import { createProductVariantsConfig } from './collections/product-variants'
 import { createCartsConfig } from './collections/carts'
 import { Addresses } from './collections/addresses'
+import { WishlistItems } from './collections/wishlist-items'
 
 export interface EcommercePluginOptions {
   enabled?: boolean
@@ -26,6 +27,7 @@ export const ecommercePlugin =
         createProductVariantsConfig(multivendorEnabled),
         createCartsConfig(multivendorEnabled, allowGuestCheckout),
         Addresses,
+        WishlistItems,
       ],
     }
   }

--- a/packages/backend/tests/unit/collections/wishlist-items-collection.unit.test.ts
+++ b/packages/backend/tests/unit/collections/wishlist-items-collection.unit.test.ts
@@ -1,0 +1,56 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+// @ts-ignore
+import { WishlistItems } from '../../../src/plugins/ecommerce/collections/wishlist-items.ts'
+
+test('create access requires authenticated user', () => {
+  const create = WishlistItems.access?.create as (args: { req: { user?: unknown } }) => boolean
+  assert.equal(create({ req: {} }), false)
+  assert.equal(create({ req: { user: { id: 'u-1' } } }), true)
+})
+
+test('read access scopes customer to own wishlist rows', () => {
+  const read = WishlistItems.access?.read as any
+  const out = read({ req: { user: { id: 'u-7', role: 'customer' } } })
+  assert.ok(typeof out === 'object' && out.user?.equals === 'u-7')
+})
+
+test('read access allows admin to see all rows', () => {
+  const read = WishlistItems.access?.read as any
+  assert.equal(read({ req: { user: { id: 'admin-1', role: 'admin' } } }), true)
+})
+
+test('beforeChange should force user for non-admin and reject duplicate', async () => {
+  const hook = WishlistItems.hooks?.beforeChange?.[0] as any
+  await assert.rejects(
+    () =>
+      hook({
+        data: { user: 'other', product: 'p-1' },
+        operation: 'create',
+        originalDoc: undefined,
+        req: {
+          user: { id: 'u-1', role: 'customer' },
+          payload: {
+            find: async () => ({ docs: [{ id: 'w-1' }] }),
+          },
+        },
+      }),
+    /already in your wishlist/,
+  )
+})
+
+test('beforeChange should keep explicit user for admin and pass non-duplicate', async () => {
+  const hook = WishlistItems.hooks?.beforeChange?.[0] as any
+  const out = await hook({
+    data: { user: 'target-user', product: 'p-9' },
+    operation: 'create',
+    originalDoc: undefined,
+    req: {
+      user: { id: 'admin-1', role: 'admin' },
+      payload: {
+        find: async () => ({ docs: [] }),
+      },
+    },
+  })
+  assert.equal(out.user, 'target-user')
+})


### PR DESCRIPTION
## Summary
- Add new `wishlist-items` ecommerce collection with owner/admin access control.
- Enforce duplicate protection in `beforeChange` hook (`user + product` uniqueness at app layer).
- Add `20260601_141500_wishlist_items` migration with `DATABASE_ID_TYPE` support (`uuid`/`serial`) and recovery-safe casting paths.
- Add `20260601_153000_add_wishlist_locked_rels` migration to align Payload internal `payload_locked_documents_rels` with wishlist relations.
- Register new collection and migrations in plugin/migration index.
- Add unit tests for access behavior and duplicate prevention.

## Why
This enables stable, production-safe wishlist persistence in Payload while keeping compatibility across different database ID strategies and preventing duplicate wishlist entries.

## Test Plan
- [x] `yarn typecheck` (backend workspace)
- [x] `yarn workspace @bs-commerce/backend test:unit --test-name-pattern "wishlist"`
- [x] Migration logic reviewed for `uuid` and `serial` env modes